### PR TITLE
Mapping persistance; fixes #72

### DIFF
--- a/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
@@ -712,7 +712,7 @@ namespace DEHPEcosimPro.Tests.DstController
 
             this.controller.CanLoadSelectedValues = false;
             this.controller.IsExperimentRunning = true;
-            Assert.IsFalse(this.controller.CanLoadSelectedValues);
+            Assert.IsTrue(this.controller.CanLoadSelectedValues);
             this.controller.IsExperimentRunning = false;
             Assert.IsFalse(this.controller.CanLoadSelectedValues);
         }

--- a/DEHPEcosimPro.Tests/MappingRules/EcosimProElementToElementDefinitionRuleTestFixture.cs
+++ b/DEHPEcosimPro.Tests/MappingRules/EcosimProElementToElementDefinitionRuleTestFixture.cs
@@ -41,6 +41,7 @@ namespace DEHPEcosimPro.Tests.MappingRules
 
     using DEHPEcosimPro.DstController;
     using DEHPEcosimPro.MappingRules;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.ViewModel.Rows;
 
     using Moq;
@@ -67,6 +68,7 @@ namespace DEHPEcosimPro.Tests.MappingRules
         private ActualFiniteStateList actualFiniteStates;
         private RatioScale scale;
         private SimpleQuantityKind quantityKindParameterType;
+        private Mock<IMappingConfigurationService> mappingConfigurationService;
 
         [SetUp]
         public void Setup()
@@ -101,12 +103,12 @@ namespace DEHPEcosimPro.Tests.MappingRules
             this.hubController.Setup(x => x.GetSiteDirectory()).Returns(new SiteDirectory());
 
             this.dstController = new Mock<IDstController>();
-            this.dstController.Setup(x => x.ExternalIdentifierMap).Returns(new ExternalIdentifierMap());
-            this.dstController.Setup(x => x.AddToExternalIdentifierMap(It.IsAny<Guid>(), It.IsAny<string>()));
+            this.mappingConfigurationService = new Mock<IMappingConfigurationService>();
 
             var containerBuilder = new ContainerBuilder();
             containerBuilder.RegisterInstance(this.hubController.Object).As<IHubController>();
             containerBuilder.RegisterInstance(this.dstController.Object).As<IDstController>();
+            containerBuilder.RegisterInstance(this.mappingConfigurationService.Object).As<IMappingConfigurationService>();
             AppContainer.Container = containerBuilder.Build();
 
             this.actualFiniteStates = new ActualFiniteStateList()

--- a/DEHPEcosimPro.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
+++ b/DEHPEcosimPro.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
@@ -26,9 +26,13 @@ namespace DEHPEcosimPro.Tests.Services.MappingConfiguration
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Types;
+
+    using CDP4Dal.Operations;
 
     using DEHPCommon.Enumerators;
     using DEHPCommon.HubController.Interfaces;
@@ -50,46 +54,83 @@ namespace DEHPEcosimPro.Tests.Services.MappingConfiguration
     {
         private MappingConfigurationService service;
         private Mock<IStatusBarControlViewModel> statusBar;
-        private Mock<IHubController> hubservice;
+        private Mock<IHubController> hubController;
         private List<ExternalIdentifier> externalIdentifiers;
         private ExternalIdentifierMap externalIdentifierMap;
+        private List<VariableRowViewModel> variables;
+        private ElementDefinition element;
+        private Parameter parameter;
 
         [SetUp]
         public void Setup()
         {
             this.statusBar = new Mock<IStatusBarControlViewModel>();
-            this.hubservice = new Mock<IHubController>();
-            this.service = new MappingConfigurationService(this.statusBar.Object, this.hubservice.Object);
+            this.hubController = new Mock<IHubController>();
+            this.service = new MappingConfigurationService(this.statusBar.Object, this.hubController.Object);
+
+            this.variables = new List<VariableRowViewModel>()
+            {
+                new VariableRowViewModel((
+                    new ReferenceDescription()
+                    {
+                        DisplayName = new LocalizedText(string.Empty, "Mos.a"),
+                        NodeId = new NodeId("Mos.a")
+                    },
+                    new DataValue() { Value = 5, ServerTimestamp = DateTime.MinValue })),
+                new VariableRowViewModel((
+                    new ReferenceDescription()
+                    {
+                        DisplayName = new LocalizedText(string.Empty, "res0"),
+                        NodeId = new NodeId("res0")
+                    },
+                    new DataValue() { Value = 5, ServerTimestamp = DateTime.MinValue }))
+                {
+                    Values =
+                    {
+                        new TimeTaggedValueRowViewModel(8, 0),
+                        new TimeTaggedValueRowViewModel(16, 1),
+                        new TimeTaggedValueRowViewModel(32, 2)
+                    }
+                }
+            };
 
             this.externalIdentifiers = new List<ExternalIdentifier>()
             {
                 new ExternalIdentifier()
                 {
                     MappingDirection = MappingDirection.FromDstToHub,
-                    Identifier = "var0",
+                    Identifier = "res0",
                     ValueIndex = 2
                 },
                 new ExternalIdentifier()
                 {
+                    MappingDirection = MappingDirection.FromDstToHub,
+                    Identifier = "res0",
+                    ValueIndex = 0
+                },
+                new ExternalIdentifier()
+                {
                     MappingDirection = MappingDirection.FromHubToDst,
-                    Identifier = "var1",
+                    Identifier = "Mos.a",
                     ValueIndex = 0,
                     ParameterSwitchKind = ParameterSwitchKind.COMPUTED
                 }
             };
 
+            this.parameter = new Parameter(Guid.NewGuid(), null, null);
+
+            this.element = new ElementDefinition(Guid.NewGuid(), null, null)
+            {
+                Parameter = {this.parameter}
+            };
+            
             this.externalIdentifierMap = new ExternalIdentifierMap(Guid.NewGuid(), null, null)
             {
-                Correspondence =
+                Correspondence = 
                 {
-                    new IdCorrespondence()
-                    {
-                        InternalThing = Guid.NewGuid(), ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[0])
-                    },
-                    new IdCorrespondence()
-                    {
-                        InternalThing = Guid.NewGuid(), ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[1])
-                    },
+                    new IdCorrespondence() { InternalThing = this.element.Iid, ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[0]) },
+                    new IdCorrespondence() { InternalThing = this.parameter.Iid, ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[1]) },
+                    new IdCorrespondence() { InternalThing = Guid.NewGuid(), ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[2]) },
                 }
             };
         }
@@ -134,31 +175,168 @@ namespace DEHPEcosimPro.Tests.Services.MappingConfiguration
                 SelectedValue = new ValueSetValueRowViewModel(
                 new ParameterValueSet()
                 {
-                    Manual = new ValueArray<string>(new List<string>(){"1","42","3"}),
-                    Computed = new ValueArray<string>(new List<string>(){"1","42","3"}),
-                    Reference = new ValueArray<string>(new List<string>(){"1","42","3"})
-                },"41", null)
+                    Manual = new ValueArray<string>(new List<string>(){"16","43","33"}),
+                    Computed = new ValueArray<string>(new List<string>(){"81","48","32"}),
+                    Reference = new ValueArray<string>(new List<string>(){"19","42","31"})
+                },"42", null)
             });
 
-            Assert.AreEqual(2, this.service.ExternalIdentifierMap.Correspondence.Count);
+            this.service.AddToExternalIdentifierMap(new MappedElementDefinitionRowViewModel()
+            {
+                SelectedVariable = new VariableRowViewModel((new ReferenceDescription()
+                {
+                    NodeId = new ExpandedNodeId("4"),
+                    DisplayName = "cata"
+                }, new DataValue("1"))),
+                SelectedValue = new ValueSetValueRowViewModel(
+                    new ParameterValueSet()
+                    {
+                        Manual = new ValueArray<string>(new List<string>() { "871", "428", "37" }),
+                        Computed = new ValueArray<string>(new List<string>() { "91", "642", "893" }),
+                        Reference = new ValueArray<string>(new List<string>() { "551", "442", "38" })
+                    }, "428", null)
+            });
+
+            this.service.AddToExternalIdentifierMap(new MappedElementDefinitionRowViewModel()
+            {
+                SelectedVariable = new VariableRowViewModel((new ReferenceDescription()
+                {
+                    NodeId = new ExpandedNodeId("4"),
+                    DisplayName = "cata"
+                }, new DataValue("1"))),
+                SelectedValue = new ValueSetValueRowViewModel(
+                    new ParameterValueSet()
+                    {
+                        Manual = new ValueArray<string>(new List<string>() { "871", "428", "37" }),
+                        Computed = new ValueArray<string>(new List<string>() { "91", "642", "893" }),
+                        Reference = new ValueArray<string>(new List<string>() { "551", "442", "38" })
+                    }, "37", null)
+            });
+
+            Assert.AreEqual(4, this.service.ExternalIdentifierMap.Correspondence.Count);
 
             this.service.AddToExternalIdentifierMap(internalId, "node23", MappingDirection.FromDstToHub); 
-            Assert.AreEqual(3, this.service.ExternalIdentifierMap.Correspondence.Count);
+            Assert.AreEqual(5, this.service.ExternalIdentifierMap.Correspondence.Count);
 
             this.service.AddToExternalIdentifierMap(internalId, 2d, "node56", MappingDirection.FromDstToHub);
-            Assert.AreEqual(4, this.service.ExternalIdentifierMap.Correspondence.Count);
+            Assert.AreEqual(6, this.service.ExternalIdentifierMap.Correspondence.Count);
             
             this.service.AddToExternalIdentifierMap(new Dictionary<ParameterOrOverrideBase, VariableRowViewModel>()
             {
-                {new Parameter(), new VariableRowViewModel((new ReferenceDescription()
                 {
-                    NodeId = new ExpandedNodeId("noe85"), DisplayName = "node85"
-                }, new DataValue("53")))},
-                {new Parameter(), new VariableRowViewModel((new ReferenceDescription()
+                    new Parameter(), new VariableRowViewModel((new ReferenceDescription()
+                    {
+                        NodeId = new ExpandedNodeId("noe85"), DisplayName = "node85"
+                    }, new DataValue("53")))},
                 {
-                    NodeId = new ExpandedNodeId("node66"), DisplayName = "node66"
-                }, new DataValue("86")))}
+                    new Parameter(), new VariableRowViewModel((new ReferenceDescription()
+                    {
+                        NodeId = new ExpandedNodeId("node66"), DisplayName = "node66"
+                    }, new DataValue("86")))
+                }
             });
+        }
+
+        [Test]
+        public void VerifyRefresh()
+        {
+            this.service.ExternalIdentifierMap = this.externalIdentifierMap;
+            Assert.AreSame(this.externalIdentifierMap, this.service.ExternalIdentifierMap);
+            var map = new ExternalIdentifierMap();
+            this.hubController.Setup(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out map));
+            Assert.DoesNotThrow(() => this.service.RefreshExternalIdentifierMap());
+            Assert.IsNotNull(this.service.ExternalIdentifierMap);
+            Assert.AreSame(map, this.service.ExternalIdentifierMap.Original);
+            Assert.AreNotSame(this.externalIdentifierMap, this.service.ExternalIdentifierMap);
+        }
+
+        [Test]
+        public void VerifyLoadMappingFromHubToDst()
+        {
+            Assert.IsNull(this.service.LoadMappingFromHubToDst(this.variables));
+            this.service.ExternalIdentifierMap = this.externalIdentifierMap;
+            this.externalIdentifierMap.Iid = Guid.Empty;
+            Assert.IsNull(this.service.LoadMappingFromHubToDst(this.variables));
+            this.externalIdentifierMap.Iid = Guid.NewGuid();
+            var correspondences = this.externalIdentifierMap.Correspondence.ToArray();
+
+            this.externalIdentifierMap.Correspondence.Clear();
+            Assert.IsNull(this.service.LoadMappingFromHubToDst(this.variables));
+            this.externalIdentifierMap.Correspondence.AddRange(correspondences);
+
+            var mappedRows = new List<MappedElementDefinitionRowViewModel>();
+            Assert.DoesNotThrow(() => mappedRows = this.service.LoadMappingFromHubToDst(this.variables));
+            ParameterValueSetBase valueSet = null;
+            this.hubController.Setup(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out valueSet));
+            Assert.DoesNotThrow(() => mappedRows = this.service.LoadMappingFromHubToDst(this.variables));
+
+           valueSet = (ParameterValueSetBase)new ParameterValueSet()
+            {
+                Computed = new ValueArray<string>(new[] { "42" })
+            };
+
+           this.hubController.Setup(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out valueSet)).Returns(true);
+           Assert.DoesNotThrow(() => mappedRows = this.service.LoadMappingFromHubToDst(this.variables));
+
+           this.hubController.Verify(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out valueSet), Times.Exactly(3)); 
+           Assert.AreEqual(1, mappedRows.Count);
+           Assert.AreEqual("42", mappedRows.First().SelectedValue.Value);
+        }
+        
+        [Test]
+        public void VerifyLoadMappingFromDstToHub()
+        {
+            this.service.ExternalIdentifierMap = this.externalIdentifierMap;
+            Assert.DoesNotThrow(() => this.service.LoadMappingFromDstToHub(this.variables));
+            
+            var thing = default(Thing);
+            Assert.DoesNotThrow(() => this.service.LoadMappingFromDstToHub(this.variables));
+
+            var parameterAsThing = (Thing) this.parameter;
+            var elementAsThing = (Thing)this.element;
+            this.hubController.Setup(x => x.GetThingById(this.parameter.Iid, It.IsAny<Iteration>(), out parameterAsThing)).Returns(true);
+            this.hubController.Setup(x => x.GetThingById(this.element.Iid, It.IsAny<Iteration>(), out elementAsThing)).Returns(true);
+
+            var mappedVariables = new List<VariableRowViewModel>();
+            Assert.DoesNotThrow(() => mappedVariables = this.service.LoadMappingFromDstToHub(this.variables));
+
+            Assert.IsNotNull(mappedVariables);
+            Assert.AreEqual(1, mappedVariables.Count);
+
+            this.hubController.Verify(x => x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out thing), Times.Exactly(6));
+        }
+
+        [Test]
+        public void VerifyPersist()
+        {
+            this.service.ExternalIdentifierMap = this.externalIdentifierMap;
+            var transactionMock = new Mock<IThingTransaction>();
+            var iteration = new Iteration();
+            Assert.DoesNotThrow(() => this.service.PersistExternalIdentifierMap(transactionMock.Object, iteration));
+
+            this.service.ExternalIdentifierMap = new ExternalIdentifierMap()
+            {
+                Correspondence = { new IdCorrespondence(Guid.NewGuid(), null, null) }
+            };
+
+            Assert.DoesNotThrow(() => this.service.PersistExternalIdentifierMap(transactionMock.Object, iteration));
+
+            Assert.AreEqual(1, iteration.ExternalIdentifierMap.Count);
+            transactionMock.Verify(x => x.CreateOrUpdate(It.IsAny<Thing>()), Times.Exactly(3));
+            transactionMock.Verify(x => x.Create(It.IsAny<Thing>(), null), Times.Exactly(3));
+        }
+
+        [Test]
+        public void VerifySelectValues()
+        {
+            this.service.ExternalIdentifierMap = this.externalIdentifierMap;
+            Assert.DoesNotThrow(() => this.service.LoadMappingFromDstToHub(this.variables));
+            Assert.DoesNotThrow(() => this.service.SelectValues(this.variables));
+            var mappedRow = this.variables.FirstOrDefault(x => x.MappingConfigurations.Any());
+
+            Assert.AreEqual(2,mappedRow?.SelectedValues.Count);
+            Assert.AreEqual(this.externalIdentifiers.First().ValueIndex,mappedRow?.SelectedValues.First().TimeStep);
+            Assert.AreEqual(this.externalIdentifiers.Last().ValueIndex,mappedRow?.SelectedValues.Last().TimeStep);
         }
     }
 }

--- a/DEHPEcosimPro.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
+++ b/DEHPEcosimPro.Tests/Services/MappingConfiguration/MappingConfigurationServiceTestFixture.cs
@@ -1,0 +1,164 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MappingConfigurationService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.Tests.Services.MappingConfiguration
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Types;
+
+    using DEHPCommon.Enumerators;
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+
+    using DEHPEcosimPro.Services.MappingConfiguration;
+    using DEHPEcosimPro.ViewModel.Rows;
+
+    using Moq;
+
+    using Newtonsoft.Json;
+
+    using NUnit.Framework;
+
+    using Opc.Ua;
+
+    [TestFixture]
+    public class MappingConfigurationServiceTestFixture
+    {
+        private MappingConfigurationService service;
+        private Mock<IStatusBarControlViewModel> statusBar;
+        private Mock<IHubController> hubservice;
+        private List<ExternalIdentifier> externalIdentifiers;
+        private ExternalIdentifierMap externalIdentifierMap;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.statusBar = new Mock<IStatusBarControlViewModel>();
+            this.hubservice = new Mock<IHubController>();
+            this.service = new MappingConfigurationService(this.statusBar.Object, this.hubservice.Object);
+
+            this.externalIdentifiers = new List<ExternalIdentifier>()
+            {
+                new ExternalIdentifier()
+                {
+                    MappingDirection = MappingDirection.FromDstToHub,
+                    Identifier = "var0",
+                    ValueIndex = 2
+                },
+                new ExternalIdentifier()
+                {
+                    MappingDirection = MappingDirection.FromHubToDst,
+                    Identifier = "var1",
+                    ValueIndex = 0,
+                    ParameterSwitchKind = ParameterSwitchKind.COMPUTED
+                }
+            };
+
+            this.externalIdentifierMap = new ExternalIdentifierMap(Guid.NewGuid(), null, null)
+            {
+                Correspondence =
+                {
+                    new IdCorrespondence()
+                    {
+                        InternalThing = Guid.NewGuid(), ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[0])
+                    },
+                    new IdCorrespondence()
+                    {
+                        InternalThing = Guid.NewGuid(), ExternalId = JsonConvert.SerializeObject(this.externalIdentifiers[1])
+                    },
+                }
+            };
+        }
+
+        [Test]
+        public void VerifyProperies()
+        {
+            Assert.IsNull(this.service.ExternalIdentifierMap);
+        }
+
+        [Test]
+        public void VerifyLoadValues()
+        {
+            Assert.True(true);
+        }
+        
+        [Test]
+        public void VerifyCreateExternalIdentifierMap()
+        {
+            var newExternalIdentifierMap = this.service.CreateExternalIdentifierMap("Name");
+            this.service.ExternalIdentifierMap = newExternalIdentifierMap;
+            Assert.AreEqual("Name", this.service.ExternalIdentifierMap.Name);
+            Assert.AreEqual("Name", this.service.ExternalIdentifierMap.ExternalModelName);
+        }
+
+        [Test]
+        public void VerifyAddToExternalIdentifierMap()
+        {
+            this.service.ExternalIdentifierMap = this.service.CreateExternalIdentifierMap("test");
+
+            var internalId = Guid.NewGuid();
+            this.service.AddToExternalIdentifierMap(internalId, this.externalIdentifiers[0]);
+            Assert.IsNotEmpty(this.service.ExternalIdentifierMap.Correspondence);
+            Assert.AreEqual(1, this.service.ExternalIdentifierMap.Correspondence.Count);
+
+            this.service.AddToExternalIdentifierMap(new MappedElementDefinitionRowViewModel() 
+            {
+                SelectedVariable = new VariableRowViewModel((new ReferenceDescription()
+                {
+                    NodeId = new ExpandedNodeId("4"), DisplayName = "cata"
+                }, new DataValue("1"))),
+                SelectedValue = new ValueSetValueRowViewModel(
+                new ParameterValueSet()
+                {
+                    Manual = new ValueArray<string>(new List<string>(){"1","42","3"}),
+                    Computed = new ValueArray<string>(new List<string>(){"1","42","3"}),
+                    Reference = new ValueArray<string>(new List<string>(){"1","42","3"})
+                },"41", null)
+            });
+
+            Assert.AreEqual(2, this.service.ExternalIdentifierMap.Correspondence.Count);
+
+            this.service.AddToExternalIdentifierMap(internalId, "node23", MappingDirection.FromDstToHub); 
+            Assert.AreEqual(3, this.service.ExternalIdentifierMap.Correspondence.Count);
+
+            this.service.AddToExternalIdentifierMap(internalId, 2d, "node56", MappingDirection.FromDstToHub);
+            Assert.AreEqual(4, this.service.ExternalIdentifierMap.Correspondence.Count);
+            
+            this.service.AddToExternalIdentifierMap(new Dictionary<ParameterOrOverrideBase, VariableRowViewModel>()
+            {
+                {new Parameter(), new VariableRowViewModel((new ReferenceDescription()
+                {
+                    NodeId = new ExpandedNodeId("noe85"), DisplayName = "node85"
+                }, new DataValue("53")))},
+                {new Parameter(), new VariableRowViewModel((new ReferenceDescription()
+                {
+                    NodeId = new ExpandedNodeId("node66"), DisplayName = "node66"
+                }, new DataValue("86")))}
+            });
+        }
+    }
+}

--- a/DEHPEcosimPro.Tests/ViewModel/Dialogs/DstLoginViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/Dialogs/DstLoginViewModelTestFixture.cs
@@ -37,6 +37,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
     using DEHPCommon.UserPreferenceHandler.UserPreferenceService;
 
     using DEHPEcosimPro.DstController;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.Settings;
     using DEHPEcosimPro.ViewModel.Dialogs;
 
@@ -56,11 +57,15 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
         private Mock<IStatusBarControlViewModel> statusBar;
         private Mock<IUserPreferenceService<AppSettings>> userPreferenceService;
         private DstLoginViewModel viewModel;
+        private Mock<IMappingConfigurationService> mappingConfigurationService;
 
         [SetUp]
         public void Setup()
         {
             RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.mappingConfigurationService = new Mock<IMappingConfigurationService>();
+
             this.dstController = new Mock<IDstController>();
             this.dstController.Setup(x => x.IsSessionOpen).Returns(true);
             this.dstController.Setup(x => x.Connect(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IUserIdentity>(), 1000)).Returns(Task.CompletedTask);
@@ -79,7 +84,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
             this.userPreferenceService.SetupProperty(s => s.UserPreferenceSettings, new AppSettings { SavedOpcUris = new List<string>() });
 
             this.viewModel = new DstLoginViewModel(this.dstController.Object, this.statusBar.Object, 
-                this.userPreferenceService.Object, this.hubController.Object);
+                this.userPreferenceService.Object, this.hubController.Object, this.mappingConfigurationService.Object);
         }
 
         [Test]

--- a/DEHPEcosimPro.Tests/ViewModel/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
@@ -44,6 +44,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
     using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
 
     using DEHPEcosimPro.DstController;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.ViewModel.Dialogs;
     using DEHPEcosimPro.ViewModel.Rows;
 
@@ -98,11 +99,15 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
         private ParameterSubscription parameterSubscriptionCompound;
         private IList<(ReferenceDescription Reference, DataValue Node)> variables;
         private MeasurementScale measurementScale;
+        private Mock<IMappingConfigurationService> mappingConfigurationService;
 
         [SetUp]
         public void Setup()
         {
             RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.mappingConfigurationService = new Mock<IMappingConfigurationService>();
+
             this.hubController = new Mock<IHubController>();
             this.dstController = new Mock<IDstController>();
             this.SetupDstData();
@@ -169,7 +174,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
                     new KeyValuePair<Iteration, Tuple<DomainOfExpertise, Participant>>(this.iteration, new Tuple<DomainOfExpertise, Participant>(this.domain, new Participant()))
                 }));
 
-            this.viewModel = new HubMappingConfigurationDialogViewModel(this.hubController.Object, this.dstController.Object, this.statusBar.Object);
+            this.viewModel = new HubMappingConfigurationDialogViewModel(this.hubController.Object, this.dstController.Object, this.statusBar.Object, this.mappingConfigurationService.Object);
 
             var browser = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object);
             this.elementDefinitionRows = new List<ElementDefinitionRowViewModel>();

--- a/DEHPEcosimPro.Tests/ViewModel/EcosimProTransferControlViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/EcosimProTransferControlViewModelTestFixture.cs
@@ -100,9 +100,20 @@ namespace DEHPEcosimPro.Tests.ViewModel
         public void VerifyTransferCommand()
         {
             Assert.IsFalse(this.viewModel.TransferCommand.CanExecute(null));
-            CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent(true));
-            Assert.IsFalse(this.viewModel.TransferCommand.CanExecute(null));
-            CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent());
+
+            this.dstController.Setup(x => x.SelectedDstMapResultToTransfer)
+                .Returns(new ReactiveList<ElementBase>()
+                {
+                    new ElementDefinition()
+                    {
+                        Parameter = { new Parameter()}
+                    }
+                });
+
+            this.dstController.Setup(x => x.MappingDirection)
+                .Returns(MappingDirection.FromDstToHub);
+
+            this.viewModel.UpdateNumberOfThingsToTransfer();
             Assert.IsTrue(this.viewModel.TransferCommand.CanExecute(null));
             
             Assert.DoesNotThrowAsync(() => this.viewModel.TransferCommand.ExecuteAsyncTask(null));

--- a/DEHPEcosimPro.Tests/ViewModel/MappingViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/MappingViewModelTestFixture.cs
@@ -62,6 +62,7 @@ namespace DEHPEcosimPro.Tests.ViewModel
         private ReactiveList<ElementBase> dstMapResult;
         private Mock<IHubController> hubController;
         private ReactiveList<MappedElementDefinitionRowViewModel> hubMapResult;
+        private Parameter parameter1;
 
         [SetUp]
         public void Setup()
@@ -92,23 +93,36 @@ namespace DEHPEcosimPro.Tests.ViewModel
 
             this.parameter0 = new Parameter(Guid.NewGuid(), null, null)
             {
-                ParameterType = new TextParameterType(), ValueSet = 
+                ParameterType = new TextParameterType(){Name = "parameterType0"}, ValueSet = 
                 {
                     new ParameterValueSet()
                     {
-                        Computed = new ValueArray<string>(new []{"-"}),
-                        Manual = new ValueArray<string>(new []{"-"}),
-                        Reference = new ValueArray<string>(new []{"-"}),
-                        Published = new ValueArray<string>(new []{"-"})
+                        Computed = new ValueArray<string>(new []{"8"}),
+                        Manual = new ValueArray<string>(new []{"5"}),
+                        Reference = new ValueArray<string>(new []{"3"})
+                    }
+                }
+            };
+
+            this.parameter1 = new Parameter(Guid.NewGuid(), null, null)
+            {
+                ParameterType = new TextParameterType(){Name = "parameterType1"}, ValueSet = 
+                {
+                    new ParameterValueSet()
+                    {
+                        Computed = new ValueArray<string>(new []{"1"}),
+                        Manual = new ValueArray<string>(new []{"2"}),
+                        Reference = new ValueArray<string>(new []{"3"})
                     }
                 }
             };
 
             this.element0 = new ElementDefinition(Guid.NewGuid(), null, null)
             {
+                Name = "element",
                 Parameter =
                 {
-                    this.parameter0,
+                    this.parameter0, this.parameter1,
                     new Parameter(Guid.NewGuid(), null, null),
                 }
             };
@@ -176,66 +190,6 @@ namespace DEHPEcosimPro.Tests.ViewModel
             this.dstMapResult.Add(this.element0);
             Assert.AreEqual(1,this.viewModel.MappingRows.Count);
             
-            var newParameter = new Parameter(Guid.NewGuid(), null, null)
-            {
-                ParameterType = new TextParameterType(),
-                ValueSet =
-                {
-                    new ParameterValueSet()
-                    {
-                        Computed = new ValueArray<string>(new []{"-"}),
-                        Manual = new ValueArray<string>(new []{"-"}),
-                        Reference = new ValueArray<string>(new []{"-"}),
-                        Published = new ValueArray<string>(new []{"-"})
-                    }
-                }
-            };
-
-            var newElement = new ElementDefinition(Guid.NewGuid(), null, null)
-            {
-                Parameter =
-                {
-                    newParameter,
-                    new Parameter(Guid.NewGuid(), null, null),
-                }
-            };
-            
-            this.dstController.Setup(x => x.ParameterVariable).Returns(new Dictionary<ParameterOrOverrideBase, VariableRowViewModel>()
-            {
-                { newParameter, this.variableRowViewModels.FirstOrDefault() }
-            });
-
-            this.dstMapResult.Add(newElement);
-            Assert.AreEqual(2, this.viewModel.MappingRows.Count);
-
-            var clone = this.element0.Clone(true);
-            clone.Iid = Guid.NewGuid();
-
-            clone.Parameter.Add(newParameter);
-
-            this.dstMapResult.Add(clone);
-            Assert.AreEqual(3, this.viewModel.MappingRows.Count);
-
-            this.dstController.Setup(x => x.ParameterVariable).Returns(new Dictionary<ParameterOrOverrideBase, VariableRowViewModel>()
-            {
-                { this.elementUsage.ParameterOverride.First(), this.variableRowViewModels.FirstOrDefault() }
-            });
-
-            this.dstMapResult.Add(this.elementUsage);
-            Assert.AreEqual(4, this.viewModel.MappingRows.Count);
-
-            this.hubMapResult.Add(new MappedElementDefinitionRowViewModel()
-            {
-                SelectedValue = new ValueSetValueRowViewModel(new ParameterValueSet(), "8", new RatioScale() ),
-                SelectedParameter = this.parameter0,
-                IsValid = true,
-                SelectedVariable = this.variableRowViewModels.FirstOrDefault()
-            });
-
-            Assert.AreEqual(5, this.viewModel.MappingRows.Count);
-
-            this.hubMapResult.Clear();
-            Assert.AreEqual(4, this.viewModel.MappingRows.Count);
             this.dstMapResult.Clear();
             Assert.AreEqual(0, this.viewModel.MappingRows.Count);
         }
@@ -252,9 +206,9 @@ namespace DEHPEcosimPro.Tests.ViewModel
             this.hubMapResult.Add(new MappedElementDefinitionRowViewModel()
             {
                 SelectedValue = new ValueSetValueRowViewModel(new ParameterValueSet(), "8", new RatioScale()),
-                SelectedParameter = this.parameter0,
+                SelectedParameter = this.parameter1,
                 IsValid = true,
-                SelectedVariable = this.variableRowViewModels.FirstOrDefault()
+                SelectedVariable = this.variableRowViewModels.Last()
             });
             
             Assert.AreEqual(180, this.viewModel.MappingRows[1].ArrowDirection);

--- a/DEHPEcosimPro.Tests/ViewModel/NetChangePreview/DstNetChangePreviewViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/NetChangePreview/DstNetChangePreviewViewModelTestFixture.cs
@@ -72,10 +72,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
             this.hubController = new Mock<IHubController>();
             this.statusBar = new Mock<IStatusBarControlViewModel>();
 
-            this.viewModel = new DstNetChangePreviewViewModel(this.dstController.Object, 
-                this.navigation.Object, this.hubController.Object, this.statusBar.Object);
-
-            this.viewModel.Variables.AddRange(new[]
+            this.dstController.Setup(x => x.VariableRowViewModels).Returns(new ReactiveList<VariableRowViewModel>()
             {
                 new VariableRowViewModel((
                     new ReferenceDescription()
@@ -93,6 +90,9 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
                     new DataValue() {Value = 5, ServerTimestamp = DateTime.MinValue}))
             });
 
+            this.viewModel = new DstNetChangePreviewViewModel(this.dstController.Object,
+                this.navigation.Object, this.hubController.Object, this.statusBar.Object);
+            
             this.parameter0 = new Parameter() { ParameterType = new BooleanParameterType()};
             this.parameter1 = new Parameter() { ParameterType = new TextParameterType()};
 

--- a/DEHPEcosimPro.Tests/ViewModel/NetChangePreview/HubNetChangePreviewViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/NetChangePreview/HubNetChangePreviewViewModelTestFixture.cs
@@ -149,7 +149,10 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
                 Container = this.iteration
             };
 
-            this.parameterOverride = new ParameterOverride(Guid.NewGuid(), null, null) { Parameter = this.parameter };
+            this.parameterOverride = new ParameterOverride(Guid.NewGuid(), null, null)
+            {
+                Parameter = this.parameter
+            };
 
             this.elementDefinition2 = new ElementDefinition(Guid.NewGuid(), null, null)
             {
@@ -157,6 +160,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
                 {
                     new ElementUsage(Guid.NewGuid(), null, null)
                     {
+                        Name = "theOverride",
                         ElementDefinition = this.elementDefinition1,
                         ParameterOverride = { this.parameterOverride}
                     },
@@ -198,7 +202,9 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
             this.hubController.Setup(x => x.Reload()).Returns(Task.CompletedTask);
             
             this.dstController = new Mock<IDstController>();
-            
+
+            this.dstController.Setup(x => x.SelectedDstMapResultToTransfer).Returns(new ReactiveList<ElementBase>());
+
             this.dstController.Setup(x => x.DstMapResult)
                 .Returns(new ReactiveList<ElementBase>() 
                 {
@@ -343,13 +349,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
             Assert.DoesNotThrow(() =>this.viewModel.UpdateTree(false));
             Assert.DoesNotThrow(() =>this.viewModel.UpdateTree(true));
         }
-
-        [Test]
-        public void VerifyOnSessionReset()
-        {
-
-        }
-
+        
         [Test]
         public void VerifyUpdateTreeBasedOnSelection()
         {
@@ -375,6 +375,16 @@ namespace DEHPEcosimPro.Tests.ViewModel.NetChangePreview
             Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateHubPreviewBasedOnSelectionEvent(this.variableRowViewModels.Take(1), null, false)));
             Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateHubPreviewBasedOnSelectionEvent(this.variableRowViewModels, null, false)));
             Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateHubPreviewBasedOnSelectionEvent(new List<VariableRowViewModel>(), null, true)));
+        }
+
+        [Test]
+        public void VerifySelectCommands()
+        {
+            Assert.DoesNotThrow(() => this.viewModel.UpdateTree(false));
+            Assert.IsTrue(this.viewModel.SelectAllCommand.CanExecute(null));
+            Assert.IsTrue(this.viewModel.DeselectAllCommand.CanExecute(null));
+            Assert.DoesNotThrow(() => this.viewModel.SelectDeselectAllForTransfer());
+            Assert.DoesNotThrow(() => this.viewModel.SelectDeselectAllForTransfer(false));
         }
     }
 }

--- a/DEHPEcosimPro/App.xaml.cs
+++ b/DEHPEcosimPro/App.xaml.cs
@@ -39,6 +39,7 @@ namespace DEHPEcosimPro
     using DEHPCommon.UserPreferenceHandler.UserPreferenceService;
 
     using DEHPEcosimPro.DstController;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.Services.OpcConnector;
     using DEHPEcosimPro.Services.OpcConnector.Interfaces;
     using DEHPEcosimPro.Services.TypeResolver;
@@ -155,6 +156,7 @@ namespace DEHPEcosimPro
             containerBuilder.RegisterType<UserPreferenceService<AppSettings>>().As<IUserPreferenceService<AppSettings>>().SingleInstance();
             containerBuilder.RegisterType<MappingEngine>().As<IMappingEngine>().WithParameter(MappingEngine.ParameterName, Assembly.GetExecutingAssembly());
             containerBuilder.RegisterType<ObjectTypeResolverService>().As<IObjectTypeResolverService>();
+            containerBuilder.RegisterType<MappingConfigurationService>().As<IMappingConfigurationService>().SingleInstance();
         }
 
         /// <summary>

--- a/DEHPEcosimPro/DstController/DstController.cs
+++ b/DEHPEcosimPro/DstController/DstController.cs
@@ -297,16 +297,6 @@ namespace DEHPEcosimPro.DstController
         {
             if (this.CanLoadSelectedValues && !isRunning)
             {
-                //Task.Run(this.LoadMapping)
-                //    .ContinueWith(t =>
-                //    {
-                //        if (t.IsFaulted)
-                //        {
-                //            this.statusBar.Append(t.Exception?.Message, StatusBarMessageSeverity.Error);
-                //        }
-
-                //        this.canLoadSelectedValues = false;
-                //    });
                 var numberOfMappedThings = this.LoadMapping();
                 this.statusBar.Append($"{numberOfMappedThings} mapped element(s) has been loaded from the saved mapping configuration " +
                                       $"{this.mappingConfigurationService.ExternalIdentifierMap.Name}");
@@ -418,7 +408,7 @@ namespace DEHPEcosimPro.DstController
                     this.Map(validMappedVariables);
                 }
 
-                return validMappedVariables.Count();
+                return validMappedVariables.Count;
             }
 
             return 0;
@@ -589,7 +579,7 @@ namespace DEHPEcosimPro.DstController
         /// <summary>
         /// Transfers the mapped variables to the Dst data source
         /// </summary>
-        public void TransferMappedThingsToDst()
+        public async Task TransferMappedThingsToDst()
         {
             foreach (var mappedElement in this.SelectedHubMapResultToTransfer
                 .Where(
@@ -614,7 +604,8 @@ namespace DEHPEcosimPro.DstController
             var (iteration, transaction) = this.GetIterationTransaction();
             this.mappingConfigurationService.PersistExternalIdentifierMap(transaction, iteration);
             transaction.CreateOrUpdate(iteration);
-            this.hubController.Write(transaction);
+            await this.hubController.Write(transaction);
+            await this.hubController.Refresh();
             this.mappingConfigurationService.RefreshExternalIdentifierMap();
 
             this.LoadMappingToDst();

--- a/DEHPEcosimPro/DstController/DstController.cs
+++ b/DEHPEcosimPro/DstController/DstController.cs
@@ -28,7 +28,9 @@ namespace DEHPEcosimPro.DstController
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Reactive.Linq;
     using System.Threading.Tasks;
+    using System.Windows;
 
     using CDP4Common;
     using CDP4Common.CommonData;
@@ -49,6 +51,7 @@ namespace DEHPEcosimPro.DstController
 
     using DEHPEcosimPro.Enumerator;
     using DEHPEcosimPro.Events;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.Services.OpcConnector;
     using DEHPEcosimPro.Services.OpcConnector.Interfaces;
     using DEHPEcosimPro.Services.TypeResolver.Interfaces;
@@ -118,6 +121,11 @@ namespace DEHPEcosimPro.DstController
         private readonly IObjectTypeResolverService objectTypeResolver;
 
         /// <summary>
+        /// The <see cref="IMappingConfigurationService"/>
+        /// </summary>
+        private readonly IMappingConfigurationService mappingConfigurationService;
+
+        /// <summary>
         /// Backing field for the <see cref="MappingDirection"/>
         /// </summary>
         private MappingDirection mappingDirection;
@@ -126,11 +134,30 @@ namespace DEHPEcosimPro.DstController
         /// The collection of (<see cref="NodeId"/> nodeId, <see cref="string"/> value) to be retransfered
         /// </summary>
         private readonly List<(NodeId NodeId, string Value)> transferedHubMapResult = new List<(NodeId NodeId, string Value)>();
+        
+        /// <summary>
+        /// Backing field for <see cref="IsExperimentRunning"/> 
+        /// </summary>
+        private bool isExperimentRunning;
+
+        /// <summary>
+        /// Backing field for <see cref="CanLoadSelectedValues"/>
+        /// </summary>
+        private bool canLoadSelectedValues;
+
+        /// <summary>
+        /// A value indicating whether the selected values saved in the mapping can be loaded
+        /// </summary>
+        public bool CanLoadSelectedValues
+        {
+            get => this.canLoadSelectedValues;
+            set => this.RaiseAndSetIfChanged(ref this.canLoadSelectedValues, value);
+        }
 
         /// <summary>
         /// Gets this running tool name
         /// </summary>
-        public string ThisToolName => this.GetType().Assembly.GetName().Name;
+        public static readonly string ThisToolName = typeof(DstController).Assembly.GetName().Name;
 
         /// <summary>
         /// Assert whether the <see cref="OpcSessionHandler.OpcSession"/> is Open
@@ -201,15 +228,24 @@ namespace DEHPEcosimPro.DstController
         public ReactiveList<MappedElementDefinitionRowViewModel> HubMapResult { get; private set; } = new ReactiveList<MappedElementDefinitionRowViewModel>();
 
         /// <summary>
-        /// Gets or sets the <see cref="ExternalIdentifierMap"/>
+        /// Gets the collection of <see cref="VariableRowViewModel"/>
         /// </summary>
-        public ExternalIdentifierMap ExternalIdentifierMap { get; set; }
-
+        public ReactiveList<VariableRowViewModel> VariableRowViewModels { get; } = new ReactiveList<VariableRowViewModel>();
+        
         /// <summary>
         /// Gets the OPC Time <see cref="NodeId"/>
         /// </summary>
         public NodeId TimeNodeId { get; private set; }
-
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether the experiment is running
+        /// </summary>
+        public bool IsExperimentRunning
+        {
+            get => this.isExperimentRunning;
+            set => this.RaiseAndSetIfChanged(ref this.isExperimentRunning, value);
+        }
+        
         /// <summary>
         /// Initializes a new <see cref="DstController"/>
         /// </summary>
@@ -221,10 +257,12 @@ namespace DEHPEcosimPro.DstController
         /// <param name="navigationService">The <see cref="INavigationService"/></param>
         /// <param name="exchangeHistory">The <see cref="IExchangeHistoryService"/></param>
         /// <param name="objectTypeResolver">The <see cref="IObjectTypeResolverService"/></param>
+        /// <param name="mappingConfigurationService">The <see cref="IMappingConfigurationService"/></param>
         public DstController(IOpcClientService opcClientService, IHubController hubController,
             IOpcSessionHandler sessionHandler, IMappingEngine mappingEngine,
             IStatusBarControlViewModel statusBar, INavigationService navigationService,
-            IExchangeHistoryService exchangeHistory, IObjectTypeResolverService objectTypeResolver)
+            IExchangeHistoryService exchangeHistory, IObjectTypeResolverService objectTypeResolver,
+            IMappingConfigurationService mappingConfigurationService)
         {
             this.opcClientService = opcClientService;
             this.hubController = hubController;
@@ -234,8 +272,61 @@ namespace DEHPEcosimPro.DstController
             this.navigation = navigationService;
             this.exchangeHistory = exchangeHistory;
             this.objectTypeResolver = objectTypeResolver;
+            this.mappingConfigurationService = mappingConfigurationService;
+            this.InitializeObservables();
+        }
 
-            this.WhenAnyValue(x => x.opcClientService.OpcClientStatusCode).Subscribe(clientStatusCode =>
+        /// <summary>
+        /// Initializes this <see cref="DstController"/> observable
+        /// </summary>
+        private void InitializeObservables()
+        {
+            this.WhenAnyValue(x => x.opcClientService.OpcClientStatusCode)
+                .Subscribe(this.WhenOpcConnectionStatusChange);
+
+            this.WhenAnyValue(x => x.IsExperimentRunning)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(this.WhenIsExperimentRunningChanged);
+        }
+
+        /// <summary>
+        /// Updates the <see cref="CanLoadSelectedValues"/> and calls the <see cref="LoadMapping"/>
+        /// </summary>
+        /// <param name="isRunning">A value indicating whether the experiment is running</param>
+        private void WhenIsExperimentRunningChanged(bool isRunning)
+        {
+            if (this.CanLoadSelectedValues && !isRunning)
+            {
+                //Task.Run(this.LoadMapping)
+                //    .ContinueWith(t =>
+                //    {
+                //        if (t.IsFaulted)
+                //        {
+                //            this.statusBar.Append(t.Exception?.Message, StatusBarMessageSeverity.Error);
+                //        }
+
+                //        this.canLoadSelectedValues = false;
+                //    });
+                var numberOfMappedThings = this.LoadMapping();
+                this.statusBar.Append($"{numberOfMappedThings} mapped element(s) has been loaded from the saved mapping configuration " +
+                                      $"{this.mappingConfigurationService.ExternalIdentifierMap.Name}");
+
+                this.canLoadSelectedValues = false;
+            }
+
+            if (isRunning)
+            {
+                this.canLoadSelectedValues = true;
+            }
+        }
+
+        /// <summary>
+        /// Updates the <see cref="Variables"/> when ever the opc connection status changes
+        /// </summary>
+        /// <param name="clientStatusCode">The <see cref="OpcClientStatusCode"/></param>
+        private void WhenOpcConnectionStatusChange(OpcClientStatusCode clientStatusCode)
+        {
+            try
             {
                 var isOpcSessionOpen = clientStatusCode == OpcClientStatusCode.Connected;
 
@@ -245,7 +336,7 @@ namespace DEHPEcosimPro.DstController
                     {
                         if (reference.NodeClass == NodeClass.Variable && reference.NodeId.NamespaceIndex == 4)
                         {
-                            this.Variables.Add((reference, this.opcClientService.ReadNode((NodeId)reference.NodeId)));
+                            this.Variables.Add((reference, this.opcClientService.ReadNode((NodeId) reference.NodeId)));
                         }
 
                         else if (reference.NodeClass == NodeClass.Method)
@@ -254,17 +345,83 @@ namespace DEHPEcosimPro.DstController
                         }
                     }
 
-                    this.TimeNodeId = (NodeId)this.References.FirstOrDefault(x => x.BrowseName.Name == "TIME")?.NodeId;
+                    this.TimeNodeId = (NodeId) this.References.FirstOrDefault(x => x.BrowseName.Name == "TIME")?.NodeId;
+
+                    this.VariableRowViewModels.AddRange(this.Variables.Select(r => new VariableRowViewModel(r)));
+                    this.LoadMapping();
                 }
                 else
                 {
                     this.Variables.Clear();
+                    Application.Current.Dispatcher.Invoke(() => this.VariableRowViewModels.Clear());
                     this.Methods.Clear();
                     this.TimeNodeId = null;
+                    this.ClearSubscriptions();
                 }
 
                 this.IsSessionOpen = isOpcSessionOpen;
-            });
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+
+        /// <summary>
+        /// Loads the saved mapping and applies the mapping rule to the <see cref="VariableRowViewModel"/>
+        /// </summary>
+        /// <returns>The number of mapped things loaded</returns>
+        public int LoadMapping()
+        {
+            return this.LoadMappingToHub() + this.LoadMappingToDst();
+        }
+
+        /// <summary>
+        /// Loads the saved mapping to the dst
+        /// </summary>
+        /// <returns>The number of mapped things loaded</returns>
+        private int LoadMappingToDst()
+        {
+            if (this.mappingConfigurationService.LoadMappingFromHubToDst(this.VariableRowViewModels) is { } mappedElements
+                            && mappedElements.Any())
+            {
+                mappedElements.ForEach(x => x.VerifyValidity());
+                var validMappedElements = mappedElements.Where(x => x.IsValid).ToList();
+
+                this.Map(validMappedElements);
+
+                return validMappedElements.Count;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Loads the saved mapping to the hub and applies the mapping rule
+        /// </summary>
+        /// <returns>The number of mapped things loaded</returns>
+        private int LoadMappingToHub()
+        {
+            if (this.mappingConfigurationService.LoadMappingFromDstToHub(this.VariableRowViewModels) is { } mappedVariables
+                && mappedVariables.Any())
+            {
+                this.mappingConfigurationService.SelectValues(mappedVariables);
+
+                var validMappedVariables = new List<VariableRowViewModel>();
+
+                Application.Current.Dispatcher.Invoke(() =>
+                    validMappedVariables = mappedVariables.Where(x => x.IsValid()).ToList());
+
+                if (validMappedVariables.Any())
+                {
+                    this.ParameterVariable.Clear();
+                    this.Map(validMappedVariables);
+                }
+
+                return validMappedVariables.Count();
+            }
+
+            return 0;
         }
 
         /// <summary>
@@ -369,6 +526,18 @@ namespace DEHPEcosimPro.DstController
         }
 
         /// <summary>
+        /// Updates <see cref="ParameterVariable"/> by adding or replacing values
+        /// </summary>
+        /// <param name="parameterNodeIds">The  </param>
+        private void UpdateParameterNodeId(Dictionary<ParameterOrOverrideBase, VariableRowViewModel> parameterNodeIds)
+        {
+            foreach (var keyValue in parameterNodeIds)
+            {
+                this.ParameterVariable[keyValue.Key] = keyValue.Value;
+            }
+        }
+
+        /// <summary>
         /// Map the provided collection using the corresponding rule in the assembly and the <see cref="MappingEngine"/>
         /// </summary>
         /// <param name="dstVariables">The <see cref="List{T}"/> of <see cref="VariableRowViewModel"/> data</param>
@@ -382,18 +551,6 @@ namespace DEHPEcosimPro.DstController
             }
 
             CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent());
-        }
-        
-        /// <summary>
-        /// Updates <see cref="ParameterVariable"/> by adding or replacing values
-        /// </summary>
-        /// <param name="parameterNodeIds">The  </param>
-        private void UpdateParameterNodeId(Dictionary<ParameterOrOverrideBase, VariableRowViewModel> parameterNodeIds)
-        {
-            foreach (var keyValue in parameterNodeIds)
-            {
-                this.ParameterVariable[keyValue.Key] = keyValue.Value;
-            }
         }
         
         /// <summary>
@@ -447,11 +604,20 @@ namespace DEHPEcosimPro.DstController
 
                 this.SelectedHubMapResultToTransfer.Remove(mappedElement);
                 this.HubMapResult.Remove(mappedElement);
-                this.AddToExternalIdentifierMap(((Thing)mappedElement.SelectedValue.Container).Iid, mappedElement.SelectedVariable.Name);
+
+                this.mappingConfigurationService.AddToExternalIdentifierMap(mappedElement);
 
                 this.exchangeHistory.Append(
                     $"Value [{mappedElement.SelectedValue.Representation}] from {mappedElement.SelectedParameter.ModelCode()} has been transfered to {mappedElement.SelectedVariable.Name}");
             }
+
+            var (iteration, transaction) = this.GetIterationTransaction();
+            this.mappingConfigurationService.PersistExternalIdentifierMap(transaction, iteration);
+            transaction.CreateOrUpdate(iteration);
+            this.hubController.Write(transaction);
+            this.mappingConfigurationService.RefreshExternalIdentifierMap();
+
+            this.LoadMappingToDst();
 
             CDPMessageBus.Current.SendMessage(new UpdateDstVariableTreeEvent(true));
         }
@@ -492,7 +658,7 @@ namespace DEHPEcosimPro.DstController
         /// <returns>An assert</returns>
         public bool WriteToDst(NodeId nodeId, double value)
         {
-            return this.opcClientService.WriteNode(nodeId, value, true);
+            return this.opcClientService.WriteNode(nodeId, value);
         }
 
         /// <summary>
@@ -537,7 +703,16 @@ namespace DEHPEcosimPro.DstController
         public void GetNextExperimentStep()
         {
             this.CallServerMethod("method_integ_cint");
-            var time = Convert.ToDouble(this.opcClientService.ReadNode(this.TimeNodeId).Value);
+
+            var result = Convert.ToDouble(this.opcClientService.ReadNode(this.TimeNodeId).Value);
+
+            var cint = this.ReadNode(this.References
+                .FirstOrDefault(x => x.BrowseName.Name == "CINT")).Value;
+
+            var places = Convert.ToDouble(cint).ToString(CultureInfo.InvariantCulture).Split('.')[1];
+
+            var time = Math.Round(result, places.Length, MidpointRounding.AwayFromZero);
+
             this.ReadAllNode(time);
         }
 
@@ -586,21 +761,24 @@ namespace DEHPEcosimPro.DstController
                     }
                 }
 
-                this.PersistExternalIdentifierMap(transaction, iterationClone);
-
                 transaction.CreateOrUpdate(iterationClone);
+
+                this.mappingConfigurationService.AddToExternalIdentifierMap(this.ParameterVariable);
+                this.mappingConfigurationService.PersistExternalIdentifierMap(transaction, iterationClone);
 
                 await this.hubController.Write(transaction);
 
                 await this.UpdateParametersValueSets();
 
                 await this.hubController.Refresh();
-                this.hubController.GetThingById(this.ExternalIdentifierMap.Iid, this.hubController.OpenIteration, out ExternalIdentifierMap map);
-                this.ExternalIdentifierMap = map.Clone(true);
+
+                this.mappingConfigurationService.RefreshExternalIdentifierMap();
 
                 this.DstMapResult.Clear();
                 this.SelectedDstMapResultToTransfer.Clear();
                 this.ParameterVariable.Clear();
+
+                this.LoadMappingToHub();
 
                 CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent(true));
             }
@@ -633,6 +811,7 @@ namespace DEHPEcosimPro.DstController
             this.UpdateParametersValueSets(transaction, this.SelectedDstMapResultToTransfer.OfType<ElementUsage>().SelectMany(x => x.ParameterOverride));
 
             transaction.CreateOrUpdate(iterationClone);
+            
             await this.hubController.Write(transaction);
         }
 
@@ -725,85 +904,6 @@ namespace DEHPEcosimPro.DstController
             return (TThing) clone;
         }
         
-        /// <summary>
-        /// Updates the configured mapping, registering the <see cref="ExternalIdentifierMap"/> and its <see cref="IdCorrespondence"/>
-        /// to a <see name="IThingTransaction"/>
-        /// </summary>
-        /// <param name="transaction">The <see cref="IThingTransaction"/></param>
-        /// <param name="iterationClone">The <see cref="Iteration"/> clone</param>
-        private void PersistExternalIdentifierMap(IThingTransaction transaction, Iteration iterationClone)
-        {
-            if (this.ExternalIdentifierMap.Iid == Guid.Empty)
-            {
-                this.ExternalIdentifierMap = this.ExternalIdentifierMap.Clone(true);
-                this.ExternalIdentifierMap.Iid = Guid.NewGuid();
-                iterationClone.ExternalIdentifierMap.Add(this.ExternalIdentifierMap);
-            }
-
-            foreach (var correspondence in this.ExternalIdentifierMap.Correspondence)
-            {
-                if (correspondence.Iid == Guid.Empty)
-                {
-                    correspondence.Iid = Guid.NewGuid();
-                    transaction.Create(correspondence);
-                }
-                else
-                {
-                    transaction.CreateOrUpdate(correspondence);
-                }
-            }
-
-            transaction.CreateOrUpdate(this.ExternalIdentifierMap);
-
-            this.statusBar.Append("Mapping configuration processed");
-        }
-
-        /// <summary>
-        /// Creates and sets the <see cref="ExternalIdentifierMap"/>
-        /// </summary>
-        /// <param name="newName">The model name to use for creating the new <see cref="ExternalIdentifierMap"/></param>
-        /// <returns>A newly created <see cref="ExternalIdentifierMap"/></returns>
-        public ExternalIdentifierMap CreateExternalIdentifierMap(string newName)
-        {
-            return new ExternalIdentifierMap()
-            {
-                Name = newName,
-                ExternalToolName = this.ThisToolName,
-                ExternalModelName = newName,
-                Owner = this.hubController.CurrentDomainOfExpertise
-            };
-        }
-
-        /// <summary>
-        /// Adds one correspondance to the <see cref="IDstController.IdCorrespondences"/>
-        /// </summary>
-        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
-        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
-        public void AddToExternalIdentifierMap(Guid internalId, string externalId)
-        {
-            if (internalId == Guid.Empty)
-            {
-                return;
-            }
-
-            if (this.ExternalIdentifierMap.Correspondence
-                .FirstOrDefault(x => x.ExternalId == externalId 
-                                     && x.InternalThing != internalId) is { } correspondence)
-            {
-                correspondence.InternalThing = internalId;
-            }
-
-            else if (!this.ExternalIdentifierMap.Correspondence
-                    .Any(x => x.ExternalId == externalId && x.InternalThing == internalId))
-            {
-                this.ExternalIdentifierMap.Correspondence.Add(new IdCorrespondence()
-                {
-                    ExternalId = externalId,
-                    InternalThing = internalId
-                });
-            }
-        }
-
         /// <summary>
         /// Pops the <see cref="CreateLogEntryDialog"/> and based on its result, either registers a new ModelLogEntry to the <see cref="transaction"/> or not
         /// </summary>

--- a/DEHPEcosimPro/DstController/DstController.cs
+++ b/DEHPEcosimPro/DstController/DstController.cs
@@ -343,7 +343,7 @@ namespace DEHPEcosimPro.DstController
                 else
                 {
                     this.Variables.Clear();
-                    Application.Current.Dispatcher.Invoke(() => this.VariableRowViewModels.Clear());
+                    this.VariableRowViewModels.Clear();
                     this.Methods.Clear();
                     this.TimeNodeId = null;
                     this.ClearSubscriptions();
@@ -351,9 +351,10 @@ namespace DEHPEcosimPro.DstController
 
                 this.IsSessionOpen = isOpcSessionOpen;
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                Console.WriteLine(e);
+                this.logger.Error(exception);
+                this.statusBar.Append("An error occured while reaching the opc server, please check the log for more details.");
             }
         }
 
@@ -397,11 +398,8 @@ namespace DEHPEcosimPro.DstController
             {
                 this.mappingConfigurationService.SelectValues(mappedVariables);
 
-                var validMappedVariables = new List<VariableRowViewModel>();
-
-                Application.Current.Dispatcher.Invoke(() =>
-                    validMappedVariables = mappedVariables.Where(x => x.IsValid()).ToList());
-
+                var validMappedVariables = mappedVariables.Where(x => x.IsValid()).ToList();
+                
                 if (validMappedVariables.Any())
                 {
                     this.ParameterVariable.Clear();

--- a/DEHPEcosimPro/DstController/IDstController.cs
+++ b/DEHPEcosimPro/DstController/IDstController.cs
@@ -47,9 +47,9 @@ namespace DEHPEcosimPro.DstController
     public interface IDstController
     {
         /// <summary>
-        /// Gets this running tool name
+        /// A value indicating whether the selected values saved in the mapping can be loaded
         /// </summary>
-        string ThisToolName { get; }
+        bool CanLoadSelectedValues { get; set; }
 
         /// <summary>
         /// Assert whether the <see cref="OpcSessionHandler.OpcSession"/> is Open
@@ -112,14 +112,25 @@ namespace DEHPEcosimPro.DstController
         ReactiveList<MappedElementDefinitionRowViewModel> HubMapResult { get; }
 
         /// <summary>
-        /// Gets or sets the <see cref="ExternalIdentifierMap"/>
+        /// Gets the collection of <see cref="VariableRowViewModel"/>
         /// </summary>
-        ExternalIdentifierMap ExternalIdentifierMap { get; set; }
+        ReactiveList<VariableRowViewModel> VariableRowViewModels { get; }
 
         /// <summary>
         /// Gets the OPC Time <see cref="NodeId"/>
         /// </summary>
         NodeId TimeNodeId { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the experiment is running
+        /// </summary>
+        bool IsExperimentRunning { get; set; }
+
+        /// <summary>
+        /// Loads the saved mapping and applies the mapping rule to the <see cref="VariableRowViewModel"/>
+        /// </summary>
+        /// <returns>The number of mapped things loaded</returns>
+        int LoadMapping();
 
         /// <summary>
         /// Connects to the provided endpoint
@@ -245,19 +256,5 @@ namespace DEHPEcosimPro.DstController
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
         Task UpdateParametersValueSets();
-
-        /// <summary>
-        /// Creates and sets the <see cref="DstController.ExternalIdentifierMap"/>
-        /// </summary>
-        /// <param name="newName">The model name to use for creating the new <see cref="DstController.ExternalIdentifierMap"/></param>
-        /// <returns>A newly created <see cref="DstController.ExternalIdentifierMap"/></returns>
-        ExternalIdentifierMap CreateExternalIdentifierMap(string newName);
-
-        /// <summary>
-        /// Adds one correspondance to the <see cref="IDstController.IdCorrespondences"/>
-        /// </summary>
-        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
-        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
-        void AddToExternalIdentifierMap(Guid internalId, string externalId);
     }
 }

--- a/DEHPEcosimPro/DstController/IDstController.cs
+++ b/DEHPEcosimPro/DstController/IDstController.cs
@@ -205,7 +205,7 @@ namespace DEHPEcosimPro.DstController
         /// <summary>
         /// Transfers the mapped variables to the Dst data source
         /// </summary>
-        void TransferMappedThingsToDst();
+        Task TransferMappedThingsToDst();
 
         /// <summary>
         /// Gets a value indicating if the <paramref name="reference"/> value can be overridden 

--- a/DEHPEcosimPro/Events/LoadMappingEvent.cs
+++ b/DEHPEcosimPro/Events/LoadMappingEvent.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="IDstReferencesViewModel.cs" company="RHEA System S.A.">
-//    Copyright (c) 2020-2020 RHEA System S.A.
+// <copyright file="LoadMappingEvent.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
@@ -22,25 +22,14 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace DEHPEcosimPro.ViewModel.Interfaces
+namespace DEHPEcosimPro.Events
 {
-    using DEHPEcosimPro.ViewModel.Rows;
-
-    using ReactiveUI;
+    using CDP4Dal;
 
     /// <summary>
-    /// Interface definition for <see cref="DstVariablesControlViewModel"/>
+    /// An event for <see cref="CDPMessageBus"/>
     /// </summary>
-    public interface IDstVariablesControlViewModel
+    public class LoadMappingEvent
     {
-        /// <summary>
-        /// Gets or sets the assert indicating whether the view is busy
-        /// </summary>
-        bool IsBusy { get; set; }
-
-        /// <summary>
-        /// Gets the collection of <see cref="VariableRowViewModel"/>
-        /// </summary>
-        ReactiveList<VariableRowViewModel> Variables { get; }
     }
 }

--- a/DEHPEcosimPro/MappingRules/EcosimProElementToElementDefinitionRule.cs
+++ b/DEHPEcosimPro/MappingRules/EcosimProElementToElementDefinitionRule.cs
@@ -37,6 +37,7 @@ namespace DEHPEcosimPro.MappingRules
     using CDP4Common.Types;
 
     using DEHPCommon;
+    using DEHPCommon.Enumerators;
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.MappingEngine;
     using DEHPCommon.MappingRules.Core;
@@ -44,6 +45,7 @@ namespace DEHPEcosimPro.MappingRules
     using DEHPEcosimPro.DstController;
     using DEHPEcosimPro.Enumerator;
     using DEHPEcosimPro.Extensions;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.ViewModel.Rows;
 
     using NLog;
@@ -67,9 +69,9 @@ namespace DEHPEcosimPro.MappingRules
         private readonly IHubController hubController = AppContainer.Container.Resolve<IHubController>();
 
         /// <summary>
-        /// The <see cref="IDstController"/>
+        /// The <see cref="IMappingConfigurationService"/>
         /// </summary>
-        private IDstController dstController;
+        private IMappingConfigurationService mappingConfigurationService;
 
         /// <summary>
         /// The current <see cref="DomainOfExpertise"/>
@@ -90,7 +92,7 @@ namespace DEHPEcosimPro.MappingRules
         {
             try
             {
-                this.dstController = AppContainer.Container.Resolve<IDstController>();
+                this.mappingConfigurationService = AppContainer.Container.Resolve<IMappingConfigurationService>();
 
                 this.owner = this.hubController.CurrentDomainOfExpertise;
 
@@ -111,7 +113,8 @@ namespace DEHPEcosimPro.MappingRules
 
                         this.AddsValueSetToTheSelectectedParameter(variable);
 
-                        this.AddToExternalIdentifierMap(variable.SelectedElementDefinition.Iid, variable.ElementName);
+                         this.mappingConfigurationService.AddToExternalIdentifierMap(
+                             variable.SelectedElementDefinition.Iid, variable.Reference.NodeId.Identifier, MappingDirection.FromDstToHub);
                     }
                 }
 
@@ -279,26 +282,18 @@ namespace DEHPEcosimPro.MappingRules
         /// <param name="variable">The external identifier: the variable name</param>
         private void AddParameterToExternalIdentifierMap(ParameterBase parameter, VariableRowViewModel variable)
         {
-            this.AddToExternalIdentifierMap(parameter.Iid, variable.Name);
-
             if (parameter.IsOptionDependent)
             {
-                this.AddToExternalIdentifierMap(variable.SelectedOption.Iid, variable.Name);
+                this.mappingConfigurationService.AddToExternalIdentifierMap(
+                    variable.SelectedOption.Iid, variable.Reference.NodeId.Identifier, MappingDirection.FromDstToHub);
             }
 
             if (parameter.StateDependence is {})
             {
-                this.AddToExternalIdentifierMap(variable.SelectedActualFiniteState.Iid, variable.Name);
+                this.mappingConfigurationService.AddToExternalIdentifierMap(
+                    variable.SelectedActualFiniteState.Iid, variable.Reference.NodeId.Identifier, MappingDirection.FromDstToHub);
             }
         }
-
-        /// <summary>
-        /// Adds one correspondance to the <see cref="IHubController.ExternalIdentifierMap"/>
-        /// </summary>
-        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
-        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
-        private void AddToExternalIdentifierMap(Guid internalId, string externalId)
-            => this.dstController.AddToExternalIdentifierMap(internalId, externalId);
     }
 }
 

--- a/DEHPEcosimPro/Services/MappingConfiguration/ExternalIdentifier.cs
+++ b/DEHPEcosimPro/Services/MappingConfiguration/ExternalIdentifier.cs
@@ -1,0 +1,65 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ExternalIdentifier.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.Services.MappingConfiguration
+{
+    using System;
+
+    using CDP4Common.EngineeringModelData;
+
+    using DEHPCommon.Enumerators;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// The <see cref="ExternalIdentifier"/> is a POCO class that represents a serializable <see cref="IdCorrespondence.ExternalId"/>
+    /// </summary>
+    [Serializable]
+    public class ExternalIdentifier
+    {
+        /// <summary>
+        /// Gets or sets the mapping direction this <see cref="ExternalIdentifier"/> applies to
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MappingDirection MappingDirection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value index this <see cref="ExternalIdentifier"/> maps to, if applicable
+        /// represents the index in the value set or the time step from experiment result
+        /// </summary>
+        public double? ValueIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier
+        /// </summary>
+        public object Identifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParameterSwitchKind"/> if applicable
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ParameterSwitchKind ParameterSwitchKind { get; set; }
+    }
+}

--- a/DEHPEcosimPro/Services/MappingConfiguration/IMappingConfigurationService.cs
+++ b/DEHPEcosimPro/Services/MappingConfiguration/IMappingConfigurationService.cs
@@ -1,0 +1,123 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IMappingConfigurationService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.Services.MappingConfiguration
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Dal.Operations;
+
+    using DEHPCommon.Enumerators;
+
+    using DEHPEcosimPro.ViewModel.Rows;
+
+    /// <summary>
+    /// The <see cref="IMappingConfigurationService"/> is the interface definition for <see cref="MappingConfigurationService"/>
+    /// </summary>
+    public interface IMappingConfigurationService
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        ExternalIdentifierMap ExternalIdentifierMap { get; set; }
+
+        /// <summary>
+        /// Selects the values as defined in the <see cref="MappingConfigurationService.ExternalIdentifierMap"/> for the mappin
+        /// </summary>
+        void SelectValues(IEnumerable<VariableRowViewModel> variableRowViewModels);
+
+        /// <summary>
+        /// Loads the mapping configuration and generates the map result respectively
+        /// </summary> 
+        /// <param name="variables">The collection of <see cref="VariableRowViewModel"/></param>
+        /// <returns>A collection of <see cref="VariableRowViewModel"/></returns>
+        List<MappedElementDefinitionRowViewModel> LoadMappingFromHubToDst(IList<VariableRowViewModel> variables);
+
+        /// <summary>
+        /// Loads the mapping configuration and generates the map result respectively
+        /// </summary>
+        /// <param name="variables">The collection of <see cref="VariableRowViewModel"/></param>
+        /// <returns>A collection of <see cref="VariableRowViewModel"/></returns>
+        List<VariableRowViewModel> LoadMappingFromDstToHub(IList<VariableRowViewModel> variables);
+
+        /// <summary>
+        /// Updates the configured mapping, registering the <see cref="MappingConfigurationService.ExternalIdentifierMap"/> and its <see cref="IdCorrespondence"/>
+        /// to a <see name="IThingTransaction"/>
+        /// </summary>
+        /// <param name="transaction">The <see cref="IThingTransaction"/></param>
+        /// <param name="iterationClone">The <see cref="Iteration"/> clone</param>
+        void PersistExternalIdentifierMap(IThingTransaction transaction, Iteration iterationClone);
+
+        /// <summary>
+        /// Creates and sets the <see cref="MappingConfigurationService.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="newName">The model name to use for creating the new <see cref="MappingConfigurationService.ExternalIdentifierMap"/></param>
+        /// <returns>A newly created <see cref="MappingConfigurationService.ExternalIdentifierMap"/></returns>
+        ExternalIdentifierMap CreateExternalIdentifierMap(string newName);
+
+        /// <summary>
+        /// Adds one correspondance to the <see cref="MappingConfigurationService.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
+        /// <param name="valueIndex">The value index</param>
+        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
+        /// <param name="mappingDirection">The <see cref="MappingDirection"/> the mapping belongs</param>
+        void AddToExternalIdentifierMap(Guid internalId, double valueIndex, object externalId, MappingDirection mappingDirection);
+
+        /// <summary>
+        /// Adds one correspondance to the <see cref="MappingConfigurationService.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="mappedElement">The <see cref="mappedElement"/></param>
+        void AddToExternalIdentifierMap(MappedElementDefinitionRowViewModel mappedElement);
+
+        /// <summary>
+        /// Adds one correspondance to the <see cref="MappingConfigurationService.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
+        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
+        /// <param name="mappingDirection">The <see cref="MappingDirection"/> the mapping belongs</param>
+        void AddToExternalIdentifierMap(Guid internalId, object externalId, MappingDirection mappingDirection);
+
+        /// <summary>
+        /// Adds as many correspondence as <paramref name="parameterVariable"/> values
+        /// </summary>
+        /// <param name="parameterVariable">The <see cref="Dictionary{T,T}"/> of mapped <see cref="ParameterOrOverrideBase"/> / <see cref="VariableRowViewModel"/></param>
+        void AddToExternalIdentifierMap(Dictionary<ParameterOrOverrideBase, VariableRowViewModel> parameterVariable);
+
+        /// <summary>
+        /// Adds one correspondence to the <see cref="MappingConfigurationService.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="internalId">The thing that <paramref name="externalIdentifier"/> corresponds to</param>
+        /// <param name="externalIdentifier">The external thing that <see cref="internalId"/> corresponds to</param>
+        void AddToExternalIdentifierMap(Guid internalId, ExternalIdentifier externalIdentifier);
+
+        /// <summary>
+        /// Refreshes the <see cref="MappingConfigurationService.ExternalIdentifierMap"/> usually done after a session write
+        /// </summary>
+        void RefreshExternalIdentifierMap();
+    }
+}

--- a/DEHPEcosimPro/Services/MappingConfiguration/MappingConfigurationService.cs
+++ b/DEHPEcosimPro/Services/MappingConfiguration/MappingConfigurationService.cs
@@ -1,0 +1,455 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MappingConfigurationService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.Services.MappingConfiguration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Windows;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Extensions;
+
+    using CDP4Dal.Operations;
+
+    using DEHPCommon.Enumerators;
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+
+    using DEHPEcosimPro.DstController;
+    using DEHPEcosimPro.ViewModel.Rows;
+
+    using Newtonsoft.Json;
+
+    using NLog;
+
+    /// <summary>
+    /// The <see cref="MappingConfigurationService"/> takes care of handling all operation
+    /// related to saving and loading configured mapping.
+    /// </summary>
+    public class MappingConfigurationService : IMappingConfigurationService
+    {
+        /// <summary>
+        /// Gets the current class logger
+        /// </summary>
+        private readonly Logger logger = LogManager.GetCurrentClassLogger();
+        
+        /// <summary>
+        /// The <see cref="IStatusBarControlViewModel"/>
+        /// </summary>
+        private readonly IStatusBarControlViewModel statusBar;
+        
+        /// <summary>
+        /// Backing field for <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        private ExternalIdentifierMap externalIdentifierMap;
+
+        /// <summary>
+        /// Gets or sets the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        public ExternalIdentifierMap ExternalIdentifierMap
+        {
+            get => this.externalIdentifierMap;
+            set
+            {
+                this.externalIdentifierMap = value;
+                this.ParseIdCorrespondence();
+            }
+        }
+        
+        /// <summary>
+        /// The <see cref="IHubController"/>
+        /// </summary>
+        private readonly IHubController hubController;
+
+        /// <summary>
+        /// The collection of id correspondence as tuple
+        /// (<see cref="Guid"/> InternalId, <see cref="ExternalIdentifier"/> externalIdentifier, <see cref="Guid"/> Iid)
+        /// including the deserialized external identifier
+        /// </summary>
+        private readonly List<(Guid InternalId, ExternalIdentifier ExternalIdentifier, Guid Iid)> correspondences 
+            = new List<(Guid InternalId, ExternalIdentifier ExternalIdentifier, Guid Iid)>();
+        
+        /// <summary>
+        /// Initializes a new <see cref="MappingConfigurationService"/>
+        /// </summary>
+        /// <param name="statusBarControl">The <see cref="IStatusBarControlViewModel"/></param>
+        /// <param name="hubController">The <see cref="IHubController"/></param>
+        public MappingConfigurationService(IStatusBarControlViewModel statusBarControl, IHubController hubController)
+        {
+            this.statusBar = statusBarControl;
+            this.hubController = hubController;
+        }
+
+        /// <summary>
+        /// Selects the values as defined in the <see cref="ExternalIdentifierMap"/> for the mapping
+        /// </summary>
+        public void SelectValues(IEnumerable<VariableRowViewModel> variableRowViewModels)
+        {
+            foreach (var rowViewModel in variableRowViewModels)
+            {
+                Application.Current.Dispatcher.Invoke(() => rowViewModel.SelectedValues.Clear());
+
+                var timeTaggedValueRowViewModels = this.correspondences
+                    .Where(x => 
+                        x.ExternalIdentifier.Identifier.Equals(rowViewModel.Reference.NodeId.Identifier) 
+                        && x.ExternalIdentifier.ValueIndex is { })
+                    .DistinctBy(x => x.ExternalIdentifier.ValueIndex)
+                    .Select(x => rowViewModel.Values.FirstOrDefault(
+                        v => Math.Abs(v.TimeStep - x.ExternalIdentifier.ValueIndex.GetValueOrDefault()) <= 0 ))
+                    .Where(x => x is {});
+
+                foreach (var value in timeTaggedValueRowViewModels)
+                {
+                    Application.Current.Dispatcher.Invoke(() => rowViewModel.SelectedValues.Add(value));
+                }
+            }
+
+            this.statusBar.Append($"Loading of the selected values from saved configuration done!");
+        }
+
+        /// <summary>
+        /// Parses the <see cref="ExternalIdentifierMap"/> correspondences and adds it to the <see cref="correspondences"/> collection
+        /// </summary>
+        private void ParseIdCorrespondence()
+        {
+            this.correspondences.Clear();
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            this.correspondences.AddRange(this.ExternalIdentifierMap.Correspondence.Select(x =>
+            (
+                x.InternalThing, JsonConvert.DeserializeObject<ExternalIdentifier>(x.ExternalId), x.Iid
+            )));
+
+            stopwatch.Stop();
+            this.logger.Debug($"{this.correspondences.Count} ExternalIdentifiers deserialized in {stopwatch.ElapsedMilliseconds} ms");
+        }
+
+        /// <summary>
+        /// Loads the mapping configuration and generates the map result respectively
+        /// </summary> 
+        /// <param name="variables">The collection of <see cref="VariableRowViewModel"/></param>
+        /// <returns>A collection of <see cref="VariableRowViewModel"/></returns>
+        public List<MappedElementDefinitionRowViewModel> LoadMappingFromHubToDst(IList<VariableRowViewModel> variables)
+        {
+            this.logger.Debug($"Loading the mapping configuration in progress");
+
+            if (this.ExternalIdentifierMap != null && this.ExternalIdentifierMap.Iid != Guid.Empty
+                                                   && this.ExternalIdentifierMap.Correspondence.Any())
+            {
+                return this.MapElementsFromTheExternalIdentifierMapToDst(variables);
+            }
+
+            this.logger.Debug($"The mapping configuration doesn't contain any mapping", StatusBarMessageSeverity.Warning);
+            return default;
+        }
+
+        /// <summary>
+        /// Loads the mapping configuration and generates the map result respectively
+        /// </summary>
+        /// <param name="variables">The collection of <see cref="VariableRowViewModel"/></param>
+        /// <returns>A collection of <see cref="VariableRowViewModel"/></returns>
+        public List<VariableRowViewModel> LoadMappingFromDstToHub(IList<VariableRowViewModel> variables)
+        {
+            this.logger.Debug($"Loading the mapping configuration in progress");
+
+            if (this.ExternalIdentifierMap != null && this.ExternalIdentifierMap.Iid != Guid.Empty 
+                                                   && this.ExternalIdentifierMap.Correspondence.Any())
+            {
+                return this.MapElementsFromTheExternalIdentifierMapToHub(variables);
+            }
+
+            this.logger.Debug($"The mapping configuration doesn't contain any mapping", StatusBarMessageSeverity.Warning);
+            return default;
+        }
+
+        /// <summary>
+        /// Maps the <see cref="VariableRowViewModel"/>s defined in the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="variableRowViewModels">The collection of <see cref="VariableRowViewModel"/></param>
+        /// <returns>A collection of <see cref="VariableRowViewModel"/></returns>
+        private List<MappedElementDefinitionRowViewModel> MapElementsFromTheExternalIdentifierMapToDst(IList<VariableRowViewModel> variableRowViewModels)
+        {
+            var mappedVariables = new List<MappedElementDefinitionRowViewModel>();
+
+            foreach (var idCorrespondences in
+                this.correspondences.Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromHubToDst)
+                    .GroupBy(x => x.ExternalIdentifier.Identifier))
+            {
+                if (variableRowViewModels.FirstOrDefault(rowViewModel =>
+                    rowViewModel.Reference.NodeId.Identifier.Equals(idCorrespondences.Key)) is not { } element)
+                {
+                    continue;
+                }
+                
+                foreach (var (internalId, externalIdentifier, _) in idCorrespondences)
+                {
+                    if (!this.hubController.GetThingById(internalId, this.hubController.OpenIteration, out ParameterValueSetBase valueSet))
+                    {
+                        continue;
+                    }
+
+                    if (!int.TryParse($"{externalIdentifier.ValueIndex}", out var index))
+                    {
+                        continue;
+                    }
+
+                    var mappedElement = new MappedElementDefinitionRowViewModel(valueSet, index, externalIdentifier.ParameterSwitchKind)
+                    {
+                        SelectedVariable = element
+                    };
+
+                    mappedVariables.Add(mappedElement);
+                }
+            }
+
+            return mappedVariables;
+        }
+        
+        /// <summary>
+        /// Maps the <see cref="VariableRowViewModel"/>s defined in the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="variableRowViewModels">The collection of <see cref="VariableRowViewModel"/></param>
+        /// <returns>A collection of <see cref="VariableRowViewModel"/></returns>
+        private List<VariableRowViewModel> MapElementsFromTheExternalIdentifierMapToHub(IList<VariableRowViewModel> variableRowViewModels)
+        {
+            var mappedVariables = new List<VariableRowViewModel>();
+
+            foreach (var idCorrespondences in 
+                this.correspondences.Where(x => x.ExternalIdentifier.MappingDirection == MappingDirection.FromDstToHub)
+                    .GroupBy(x => x.ExternalIdentifier.Identifier))
+            {
+                if (variableRowViewModels.FirstOrDefault(rowViewModel =>
+                    rowViewModel.Reference.NodeId.Identifier.Equals(idCorrespondences.Key)) is not { } element)
+                {
+                    continue;
+                }
+
+                this.LoadsCorrespondances(element, idCorrespondences);
+                element.MappingConfigurations.AddRange(this.ExternalIdentifierMap.Correspondence.Where(x => idCorrespondences.Any(c => c.Iid == x.Iid)).ToList());
+                mappedVariables.Add(element);
+            }
+            
+            return mappedVariables;
+        }
+
+        /// <summary>
+        ///  Loads referenced <see cref="Thing"/>s
+        /// </summary>
+        /// <param name="element">The <see cref="VariableRowViewModel"/></param>
+        /// <param name="idCorrespondences">The collection of <see cref="IdCorrespondence"/></param>
+        private void LoadsCorrespondances(VariableRowViewModel element, IEnumerable<(Guid InternalId, ExternalIdentifier ExternalIdentifier, Guid Iid)> idCorrespondences)
+        {
+            foreach (var idCorrespondence in idCorrespondences)
+            {
+                if (!this.hubController.GetThingById(idCorrespondence.InternalId, this.hubController.OpenIteration, out Thing thing))
+                {
+                    continue;
+                }
+
+                Action action = thing switch
+                {
+                    ElementDefinition elementDefinition => () => element.SelectedElementDefinition = elementDefinition.Clone(true),
+                    ElementUsage elementUsage => () => element.SelectedElementUsages.Add(elementUsage.Clone(true)),
+                    Parameter parameter => () => element.SelectedParameter = parameter.Clone(true),
+                    Option option => () => element.SelectedOption = option.Clone(false),
+                    ActualFiniteState state => () => element.SelectedActualFiniteState = state.Clone(false),
+                    _ => null
+                };
+
+                if (element.SelectedParameter is { } selectedParameter)
+                {
+                    Application.Current.Dispatcher.Invoke(() => element.SelectedParameterType = selectedParameter.ParameterType);
+                }
+
+                Application.Current.Dispatcher.Invoke(() => action?.Invoke() );
+            }
+        }
+        
+        /// <summary>
+        /// Updates the configured mapping, registering the <see cref="ExternalIdentifierMap"/> and its <see cref="IdCorrespondence"/>
+        /// to a <see name="IThingTransaction"/>
+        /// </summary>
+        /// <param name="transaction">The <see cref="IThingTransaction"/></param>
+        /// <param name="iterationClone">The <see cref="Iteration"/> clone</param>
+        public void PersistExternalIdentifierMap(IThingTransaction transaction, Iteration iterationClone)
+        {
+            if (this.ExternalIdentifierMap.Iid == Guid.Empty)
+            {
+                this.ExternalIdentifierMap = this.ExternalIdentifierMap.Clone(true);
+                this.ExternalIdentifierMap.Iid = Guid.NewGuid();
+                iterationClone.ExternalIdentifierMap.Add(this.ExternalIdentifierMap);
+            }
+
+            foreach (var correspondence in this.ExternalIdentifierMap.Correspondence)
+            {
+                if (correspondence.Iid == Guid.Empty)
+                {
+                    correspondence.Iid = Guid.NewGuid();
+                    transaction.Create(correspondence);
+                }
+                else
+                {
+                    transaction.CreateOrUpdate(correspondence);
+                }
+            }
+
+            transaction.CreateOrUpdate(this.ExternalIdentifierMap);
+
+            this.statusBar.Append("Mapping configuration processed");
+        }
+
+        /// <summary>
+        /// Creates and sets the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="newName">The model name to use for creating the new <see cref="ExternalIdentifierMap"/></param>
+        /// <returns>A newly created <see cref="ExternalIdentifierMap"/></returns>
+        public ExternalIdentifierMap CreateExternalIdentifierMap(string newName)
+        {
+            return new ExternalIdentifierMap()
+            {
+                Name = newName,
+                ExternalToolName = DstController.ThisToolName,
+                ExternalModelName = newName,
+                Owner = this.hubController.CurrentDomainOfExpertise
+            };
+        }
+
+        /// <summary>
+        /// Adds one correspondance to the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
+        /// <param name="valueIndex">The value index</param>
+        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
+        /// <param name="mappingDirection">The <see cref="MappingDirection"/> the mapping belongs</param>
+        public void AddToExternalIdentifierMap(Guid internalId, double valueIndex, object externalId, MappingDirection mappingDirection)
+        {
+            this.AddToExternalIdentifierMap(internalId, new ExternalIdentifier
+            {
+                Identifier = externalId, MappingDirection = mappingDirection, ValueIndex = valueIndex
+            });
+        }
+
+        /// <summary>
+        /// Adds one correspondance to the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="mappedElement">The <see cref="mappedElement"/></param>
+        public void AddToExternalIdentifierMap(MappedElementDefinitionRowViewModel mappedElement)
+        {
+            var (index, switchKind) = mappedElement.SelectedValue.GetValueIndexAndParameterSwitchKind();
+
+            this.AddToExternalIdentifierMap(((Thing)mappedElement.SelectedValue.Container).Iid, new ExternalIdentifier
+            {
+                Identifier = mappedElement.SelectedVariable.Reference.NodeId.Identifier,
+                MappingDirection = MappingDirection.FromHubToDst, ValueIndex = index, ParameterSwitchKind = switchKind
+            });
+        }
+
+        /// <summary>
+        /// Adds one correspondance to the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="internalId">The thing that <see cref="externalId"/> corresponds to</param>
+        /// <param name="externalId">The external thing that <see cref="internalId"/> corresponds to</param>
+        /// <param name="mappingDirection">The <see cref="MappingDirection"/> the mapping belongs</param>
+        public void AddToExternalIdentifierMap(Guid internalId, object externalId, MappingDirection mappingDirection)
+        {
+            this.AddToExternalIdentifierMap(internalId, new ExternalIdentifier
+            {
+                Identifier = externalId, MappingDirection = mappingDirection
+            });
+        }
+
+        /// <summary>
+        /// Adds as many correspondence as <paramref name="parameterVariable"/> values
+        /// </summary>
+        /// <param name="parameterVariable">The <see cref="Dictionary{T,T}"/> of mapped <see cref="ParameterOrOverrideBase"/> / <see cref="VariableRowViewModel"/></param>
+        public void AddToExternalIdentifierMap(Dictionary<ParameterOrOverrideBase, VariableRowViewModel> parameterVariable)
+        {
+            var oldCount = this.ExternalIdentifierMap.Correspondence.Count;
+
+            foreach (var variable in parameterVariable)
+            {
+                foreach (var timeTaggedValue in variable.Value.SelectedValues)
+                {
+                    this.AddToExternalIdentifierMap(Guid.Empty, timeTaggedValue.TimeStep, variable.Value.Reference.NodeId.Identifier, MappingDirection.FromDstToHub);
+                }
+
+                this.AddToExternalIdentifierMap(variable.Key.Iid, new ExternalIdentifier() { Identifier = variable.Value.Reference.NodeId.Identifier });
+
+                if (variable.Key.GetContainerOfType<ElementUsage>() is { } elementUsage)
+                {
+                    this.AddToExternalIdentifierMap(elementUsage.Iid, new ExternalIdentifier() { Identifier = variable.Value.Reference.NodeId.Identifier });
+                }
+
+                else if (variable.Key.GetContainerOfType<ElementDefinition>() is { } elementDefinition)
+                {
+                    this.AddToExternalIdentifierMap(elementDefinition.Iid, new ExternalIdentifier() { Identifier = variable.Value.Reference.NodeId.Identifier });
+                }
+            }
+
+            this.logger.Debug($"{this.ExternalIdentifierMap.Correspondence.Count-oldCount} correspondences added to the ExternalIdentifierMap");
+        }
+
+        /// <summary>
+        /// Adds one correspondence to the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="internalId">The thing that <paramref name="externalIdentifier"/> corresponds to</param>
+        /// <param name="externalIdentifier">The external thing that <see cref="internalId"/> corresponds to</param>
+        public void AddToExternalIdentifierMap(Guid internalId, ExternalIdentifier externalIdentifier)
+        {
+            var (_, _, correspondenceIid) = this.correspondences.FirstOrDefault(x =>
+                x.InternalId == internalId
+                && externalIdentifier.Identifier.Equals(x.ExternalIdentifier.Identifier)
+                && externalIdentifier.MappingDirection == x.ExternalIdentifier.MappingDirection);
+
+            if (correspondenceIid != Guid.Empty
+                && this.ExternalIdentifierMap.Correspondence.FirstOrDefault(x => x.Iid == correspondenceIid)
+                is { } correspondence)
+            {
+                correspondence.InternalThing = internalId;
+                correspondence.ExternalId = JsonConvert.SerializeObject(externalIdentifier);
+            }
+
+            this.ExternalIdentifierMap.Correspondence.Add(new IdCorrespondence()
+            {
+                ExternalId = JsonConvert.SerializeObject(externalIdentifier),
+                InternalThing = internalId
+            });
+        }
+
+        /// <summary>
+        /// Refreshes the <see cref="ExternalIdentifierMap"/> usually done after a session write
+        /// </summary>
+        public void RefreshExternalIdentifierMap()
+        {
+            this.hubController.GetThingById(this.ExternalIdentifierMap.Iid, this.hubController.OpenIteration, out ExternalIdentifierMap map);
+            this.ExternalIdentifierMap = map.Clone(true);
+        }
+    }
+}

--- a/DEHPEcosimPro/ViewModel/Dialogs/DstLoginViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Dialogs/DstLoginViewModel.cs
@@ -41,6 +41,7 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
 
     using DEHPEcosimPro.Settings;
     using DEHPEcosimPro.DstController;
+    using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.ViewModel.Dialogs.Interfaces;
 
     using Opc.Ua;
@@ -66,7 +67,12 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
         /// The <see cref="IUserPreferenceService{AppSettings}"/> instance
         /// </summary>
         private readonly IUserPreferenceService<AppSettings> userPreferenceService;
-        
+
+        /// <summary>
+        /// The <see cref="IMappingConfigurationService"/>
+        /// </summary>
+        private readonly IMappingConfigurationService mappingConfiguration;
+
         /// <summary>
         /// Backing field for <see cref="IsBusy"/>
         /// </summary>
@@ -225,12 +231,15 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
         /// <param name="statusBarControlView">The <see cref="IStatusBarControlViewModel"/></param>
         /// <param name="userPreferenceService">The <see cref="IUserPreferenceService{AppSettings}"/></param>
         /// <param name="hubController">The <see cref="IHubController"/></param>
+        /// <param name="mappingConfiguration">The <see cref="IMappingConfigurationService"/></param>
         public DstLoginViewModel(IDstController dstController, IStatusBarControlViewModel statusBarControlView, 
-            IUserPreferenceService<AppSettings> userPreferenceService, IHubController hubController)
+            IUserPreferenceService<AppSettings> userPreferenceService, IHubController hubController,
+            IMappingConfigurationService mappingConfiguration)
         {
             this.dstController = dstController;
             this.statusBarControlView = statusBarControlView;
             this.userPreferenceService = userPreferenceService;
+            this.mappingConfiguration = mappingConfiguration;
 
             this.PopulateSavedUris();
 
@@ -241,7 +250,8 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
             this.SaveCurrentUriCommand.Subscribe(_ => this.ExecuteSaveCurrentUri());
 
             this.AvailableExternalIdentifierMap = new ReactiveList<ExternalIdentifierMap>(
-                hubController.AvailableExternalIdentifierMap(this.dstController.ThisToolName));
+                hubController.AvailableExternalIdentifierMap(DstController.ThisToolName)
+                    .OrderBy(x => x.Name));
 
             this.WhenAnyValue(x => x.SelectedExternalIdentifierMap).Subscribe(_ =>
             {
@@ -361,12 +371,12 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
         }
 
         /// <summary>
-        /// Creates a new <see cref="ExternalIdentifierMap"/> and or set the <see cref="IDstController.ExternalIdentifierMap"/>
+        /// Creates a new <see cref="ExternalIdentifierMap"/> and or set the <see cref="IMappingConfigurationService.ExternalIdentifierMap"/>
         /// </summary>
         private void ProcessExternalIdentifierMap()
         {
-            this.dstController.ExternalIdentifierMap = this.SelectedExternalIdentifierMap?.Clone(true) ??
-                                                       this.dstController.CreateExternalIdentifierMap(this.ExternalIdentifierMapNewName);
+            this.mappingConfiguration.ExternalIdentifierMap = this.SelectedExternalIdentifierMap?.Clone(true) ??
+                                                       this.mappingConfiguration.CreateExternalIdentifierMap(this.ExternalIdentifierMapNewName);
         }
     }
 }

--- a/DEHPEcosimPro/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Dialogs/HubMappingConfigurationDialogViewModel.cs
@@ -54,11 +54,6 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
     public class HubMappingConfigurationDialogViewModel : MappingConfigurationDialogViewModel, IHubMappingConfigurationDialogViewModel
     {
         /// <summary>
-        /// The <see cref="IMappingConfigurationService"/>
-        /// </summary>
-        private readonly IMappingConfigurationService mappingService;
-
-        /// <summary>
         /// Gets or sets the collection of available variables
         /// </summary>
         public ReactiveList<VariableRowViewModel> AvailableVariables { get; set; }
@@ -184,12 +179,10 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
         /// <param name="hubController">The <see cref="IHubController"/></param>
         /// <param name="dstController">The <see cref="IDstController"/></param>
         /// <param name="statusBar">The <see cref="IStatusBarControlViewModel"/></param>
-        /// <param name="mappingService">The <see cref="IMappingConfigurationService"/></param>
         public HubMappingConfigurationDialogViewModel(IHubController hubController,
             IDstController dstController, IStatusBarControlViewModel statusBar, IMappingConfigurationService mappingService) :
             base(hubController, dstController, statusBar)
         {
-            this.mappingService = mappingService;
             this.UpdateProperties();
             this.InitializesCommandsAndObservableSubscriptions();
         }
@@ -408,6 +401,8 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
             {
                 this.MappedElements.Add(this.CreateMappedElement(parameterOverride));
             }
+
+            this.CheckCanExecute();
         }
 
         /// <summary>

--- a/DEHPEcosimPro/ViewModel/Dialogs/Interfaces/IDstMappingConfigurationDialogViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Dialogs/Interfaces/IDstMappingConfigurationDialogViewModel.cs
@@ -24,6 +24,9 @@
 
 namespace DEHPEcosimPro.ViewModel.Dialogs.Interfaces
 {
+    using System.Reactive.Linq;
+    using System.Windows.Input;
+
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -41,6 +44,11 @@ namespace DEHPEcosimPro.ViewModel.Dialogs.Interfaces
         /// Gets or sets the selected row that represents a <see cref="ReferenceDescription"/>
         /// </summary>
         VariableRowViewModel SelectedThing { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="MappingConfigurationDialogViewModel.ContinueCommand"/> can execute
+        /// </summary>
+        bool CanContinue { get; set; }
 
         /// <summary>
         /// Gets the collection of the available <see cref="Option"/> from the connected Hub Model
@@ -76,11 +84,6 @@ namespace DEHPEcosimPro.ViewModel.Dialogs.Interfaces
         /// Gets the collection of <see cref="VariableRowViewModel"/>
         /// </summary>
         ReactiveList<VariableRowViewModel> Variables { get; }
-        
-        /// <summary>
-        /// Gets or sets a value indicating whether <see cref="MappingConfigurationDialogViewModel.ContinueCommand"/> can execute
-        /// </summary>
-        bool CanContinue { get; set; }
 
         /// <summary>
         /// Gets or sets the command that applies the configured time step at the current <see cref="SelectedThing"/>
@@ -91,7 +94,38 @@ namespace DEHPEcosimPro.ViewModel.Dialogs.Interfaces
         /// Initializes this view model properties
         /// </summary>
         void Initialize();
-        
+
+        /// <summary>
+        /// Initializes this view model <see cref="ICommand"/> and <see cref="Observable"/>
+        /// </summary>
+        void InitializesCommandsAndObservableSubscriptions();
+
+        /// <summary>
+        /// Verify that the selected <see cref="ParameterType"/> is compatible with the selected variable value type
+        /// </summary>
+        void NotifyIfParameterTypeIsNotAllowed();
+
+        /// <summary>
+        /// Sets the <see cref="DstMappingConfigurationDialogViewModel.SelectedThing"/> <see cref="ParameterType"/> according to the selected <see cref="Parameter"/>
+        /// </summary>
+        void UpdateSelectedParameterType();
+
+        /// <summary>
+        /// Sets the <see cref="DstMappingConfigurationDialogViewModel.SelectedThing"/> <see cref="MeasurementScale"/> according to the selected <see cref="Parameter"/> and the selected <see cref="ParameterType"/>
+        /// </summary>
+        void UpdateSelectedScale();
+
+        /// <summary>
+        /// Sets the <see cref="DstMappingConfigurationDialogViewModel.SelectedThing"/> <see cref="Parameter"/> according to the selected <see cref="ParameterType"/>
+        /// </summary>
+        void UpdateSelectedParameter();
+
+        /// <summary>
+        /// Updates the <see cref="DstMappingConfigurationDialogViewModel.AvailableParameterTypes"/>
+        /// </summary>
+        /// <param name="allowScalarParameterType">A value indicating whether the <see cref="ScalarParameterType"/>s should be included in the <see cref="DstMappingConfigurationDialogViewModel.AvailableParameterTypes"/></param>
+        void UpdateAvailableParameterType(bool? allowScalarParameterType = null);
+
         /// <summary>
         /// Updates the mapping based on the available 10-25 elements
         /// </summary>

--- a/DEHPEcosimPro/ViewModel/DstDataSourceViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/DstDataSourceViewModel.cs
@@ -98,7 +98,7 @@ namespace DEHPEcosimPro.ViewModel
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(this.UpdateConnectButtonText);
 
-            this.WhenAnyValue(x => x.DstBrowserHeader.IsExperimentRunning)
+            this.WhenAnyValue(x => x.dstController.IsExperimentRunning)
                 .Subscribe(x => this.DstVariablesViewModel.IsBusy = x);
         }
 

--- a/DEHPEcosimPro/ViewModel/EcosimProTransferControlViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/EcosimProTransferControlViewModel.cs
@@ -43,6 +43,8 @@ namespace DEHPEcosimPro.ViewModel
     using DEHPEcosimPro.DstController;
     using DEHPEcosimPro.Events;
 
+    using NLog;
+
     using ReactiveUI;
 
     /// <summary>
@@ -50,6 +52,11 @@ namespace DEHPEcosimPro.ViewModel
     /// </summary>
     public class EcosimProTransferControlViewModel : TransferControlViewModel
     {
+        /// <summary>
+        /// The <see cref="NLog.Logger"/>
+        /// </summary>
+        private readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// The <see cref="IDstController"/>
         /// </summary>
@@ -104,15 +111,7 @@ namespace DEHPEcosimPro.ViewModel
             this.dstController = dstController;
             this.statusBar = statusBar;
             this.exchangeHistoryService = exchangeHistoryService;
-
-            CDPMessageBus.Current.Listen<UpdateObjectBrowserTreeEvent>()
-                .Select(x => !x.Reset).ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(this.UpdateCanTransfer);
-
-            CDPMessageBus.Current.Listen<UpdateDstVariableTreeEvent>()
-                .Select(x => !x.Reset).ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(this.UpdateCanTransfer);
-
+            
             this.dstController.SelectedDstMapResultToTransfer.CountChanged.Subscribe(_ => this.UpdateNumberOfThingsToTransfer());
             this.dstController.SelectedHubMapResultToTransfer.CountChanged.Subscribe(_ => this.UpdateNumberOfThingsToTransfer());
 
@@ -126,9 +125,10 @@ namespace DEHPEcosimPro.ViewModel
 
             this.TransferCommand.ThrownExceptions
                 .ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(e =>
+                .Subscribe(exception =>
                 {
-                    this.statusBar.Append($"{e.Message}", StatusBarMessageSeverity.Error);
+                    this.statusBar.Append($"{exception.Message}", StatusBarMessageSeverity.Error);
+                    this.logger.Error(exception);
                 });
             
             var canCancel = this.WhenAnyValue(x => x.AreThereAnyTransferInProgress);
@@ -141,7 +141,7 @@ namespace DEHPEcosimPro.ViewModel
         /// <summary>
         /// Updates the <see cref="TransferControlViewModel.NumberOfThing"/>
         /// </summary>
-        private void UpdateNumberOfThingsToTransfer()
+        public void UpdateNumberOfThingsToTransfer()
         {
             this.NumberOfThing = this.dstController.MappingDirection switch
             {
@@ -153,8 +153,7 @@ namespace DEHPEcosimPro.ViewModel
 
             this.UpdateCanTransfer(this.NumberOfThing > 0);
         }
-
-
+        
         /// <summary>
         /// Updates the <see cref="CanTransfer"/>
         /// </summary>

--- a/DEHPEcosimPro/ViewModel/EcosimProTransferControlViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/EcosimProTransferControlViewModel.cs
@@ -197,7 +197,7 @@ namespace DEHPEcosimPro.ViewModel
             }
             else
             {
-                this.dstController.TransferMappedThingsToDst();
+                await this.dstController.TransferMappedThingsToDst();
             }
 
             await this.exchangeHistoryService.Write();

--- a/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Interfaces/IDstBrowserHeaderViewModel.cs
@@ -53,12 +53,7 @@ namespace DEHPEcosimPro.ViewModel.Interfaces
         /// Gets or sets the experiment progress value
         /// </summary>
         double ExperimentProgress { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the experiment is running
-        /// </summary>
-        bool IsExperimentRunning { get; set; }
-
+        
         /// <summary>
         /// Gets or sets the CINT of the experiment
         /// </summary>

--- a/DEHPEcosimPro/ViewModel/MappingViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/MappingViewModel.cs
@@ -28,6 +28,7 @@ namespace DEHPEcosimPro.ViewModel
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
+    using System.Windows;
 
     using CDP4Common.EngineeringModelData;
 
@@ -117,6 +118,9 @@ namespace DEHPEcosimPro.ViewModel
         /// <param name="mappedElement">The <see cref="MappedElementDefinitionRowViewModel"/></param>
         private void UpdateMappedThings(MappedElementDefinitionRowViewModel mappedElement)
         {
+            this.MappingRows.RemoveAll(this.MappingRows
+                .Where(m => m.HubThing.Name == mappedElement.SelectedParameter.ModelCode()
+                            && m.Direction == MappingDirection.FromHubToDst).ToList());
             this.MappingRows.Add(new MappingRowViewModel(this.dstController.MappingDirection, mappedElement));
         }
 
@@ -133,9 +137,10 @@ namespace DEHPEcosimPro.ViewModel
                 _ => new List<(ParameterOrOverrideBase parameter, VariableRowViewModel variable)>()
             };
 
-            foreach (var parameter in parametersNodeId)
+            foreach (var parameterVariable in parametersNodeId)
             {
-                this.MappingRows.Add(new MappingRowViewModel(this.dstController.MappingDirection, parameter));
+                this.MappingRows.RemoveAll(this.MappingRows.Where(m => m.DstThing.Name == parameterVariable.variable.Name).ToList());
+                this.MappingRows.Add(new MappingRowViewModel(this.dstController.MappingDirection, parameterVariable));
             }
         }
 
@@ -148,7 +153,9 @@ namespace DEHPEcosimPro.ViewModel
         {
             var modified  = this.dstController
                         .ParameterVariable.Where(x =>
-                            x.Key.Container?.Iid == element.Iid).ToList();
+                            x.Key.Container is ElementDefinition elementDefinition 
+                            && elementDefinition.Iid == element.Iid 
+                            && elementDefinition.ShortName == element.ShortName).ToList();
 
             var originals = this.hubController.OpenIteration.Element
                 .FirstOrDefault(x => x.Iid == element.Iid)?

--- a/DEHPEcosimPro/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -253,7 +253,6 @@ namespace DEHPEcosimPro.ViewModel.NetChangePreview
                 variable.ShouldListenToChangeMessage = true;
                 variable.IsSelectedForTransfer = false;
                 variable.ActualValue = this.DstController.ReadNode(variable.Reference);
-                CDPMessageBus.Current.SendMessage(new DstHighlightEvent(variable.Reference.NodeId.Identifier, false));
             }
         }
 
@@ -281,8 +280,9 @@ namespace DEHPEcosimPro.ViewModel.NetChangePreview
             {
                 return;
             }
-
+            
             CDPMessageBus.Current.SendMessage(new DstHighlightEvent(variableChanged.Reference.NodeId.Identifier));
+
             variableChanged.ActualValue = mappedElement.SelectedValue.Value;
             variableChanged.ShouldListenToChangeMessage = false;
         }

--- a/DEHPEcosimPro/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -215,11 +215,30 @@ namespace DEHPEcosimPro.ViewModel.NetChangePreview
         /// <summary>
         /// Verifies that the <see cref="thingViewModel"/> is transferable
         /// </summary>
+        /// <param name="thingViewModel">The <see cref="ParameterOrOverrideBaseRowViewModel"/></param>
+        /// <returns>An assert</returns>
+        private bool IsThingTransferable(ParameterOrOverrideBaseRowViewModel thingViewModel)
+        {
+            var thingContainer = thingViewModel.ContainerViewModel.Thing;
+
+            var element = this.dstController.DstMapResult
+                .FirstOrDefault(x => x.ShortName == (thingContainer as IShortNamedThing)?.ShortName && x.Iid == thingContainer.Iid);
+
+            return element?.Iid == Guid.Empty || element?.Original != null;
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="thingViewModel"/> is transferable
+        /// </summary>
+        /// <typeparam name="TElement">The type of <see cref="ElementBase"/></typeparam>
         /// <param name="thingViewModel"></param>
         /// <returns>An assert</returns>
-        private static bool IsThingTransferable(IRowViewModelBase<Thing> thingViewModel)
+        private bool IsThingTransferable<TElement>(IViewModelBase<TElement> thingViewModel) where TElement : ElementBase
         {
-            return thingViewModel.Thing.Iid == Guid.Empty || thingViewModel.Thing.Original != null;
+            var element = this.dstController.DstMapResult.OfType<TElement>()
+                .FirstOrDefault(x => x.Iid == thingViewModel.Thing.Iid && x.ShortName == thingViewModel.Thing.ShortName);
+
+            return element?.Iid == Guid.Empty || element?.Original != null;
         }
 
         /// <summary>

--- a/DEHPEcosimPro/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -370,8 +370,8 @@ namespace DEHPEcosimPro.ViewModel.NetChangePreview
             var selectedParameters = parentViewModel.ContainedRows
                 .OfType<ParameterOrOverrideBaseRowViewModel>()
                 .Where(x => x.IsSelectedForTransfer)
-                .Select(x => x.Thing)
-                .Cast<TParameter>()
+                .Select(x => x.Thing as TParameter)
+                .Where(x => x is {})
                 .ToList();
             
             parametersToAdd

--- a/DEHPEcosimPro/ViewModel/Rows/MappedElementDefinitionRowViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Rows/MappedElementDefinitionRowViewModel.cs
@@ -107,14 +107,25 @@ namespace DEHPEcosimPro.ViewModel.Rows
         }
 
         /// <summary>
+        /// Initializes a new <see cref="MappedElementDefinitionRowViewModel"/>
+        /// </summary>
+        /// <param name="valueSet">The <see cref="IValueSet"/></param>
+        /// <param name="valueIndex">The value index</param>
+        /// <param name="switchKind">The <see cref="ParameterSwitchKind"/></param>
+        public MappedElementDefinitionRowViewModel(IValueSet valueSet, int valueIndex, ParameterSwitchKind switchKind) : this()
+        {
+            this.SelectedParameter = (valueSet as ParameterValueSetBase)?.GetContainerOfType<ParameterOrOverrideBase>();
+            this.SelectedValue = new ValueSetValueRowViewModel(valueSet, valueIndex, switchKind);
+        }
+
+        /// <summary>
         /// Verify validity of the this <see cref="MappedElementDefinitionRowViewModel"/>
         /// </summary>
         public void VerifyValidity()
         {
             this.IsValid = this.SelectedValue != null && 
                            this.SelectedValue.Value != "-" && 
-                           this.SelectedVariable != null && 
-                           this.SelectedVariable.HasWriteAccess == true;
+                           this.SelectedVariable != null;
         }
     }
 }

--- a/DEHPEcosimPro/ViewModel/Rows/VariableRowViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Rows/VariableRowViewModel.cs
@@ -333,7 +333,7 @@ namespace DEHPEcosimPro.ViewModel.Rows
         }
 
         /// <summary>
-        /// Updates the <see cref="SelectedValues"/> based on <see cref="SelectedTimeUnit"/>
+        /// Updates the <see cref="SelectedValues"/> based on <see cref="SelectedTimeStep"/>
         /// and <see cref="SelectedTimeStep"/>
         /// </summary>
         public void ApplyTimeStep()

--- a/DEHPEcosimPro/Views/Dialogs/DstMappingConfigurationDialog.xaml
+++ b/DEHPEcosimPro/Views/Dialogs/DstMappingConfigurationDialog.xaml
@@ -11,7 +11,11 @@
                    xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid" 
                    xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-                   xmlns:system="clr-namespace:System;assembly=mscorlib" Title="Mapping Configuration Dialog" MinWidth="800"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib"
+                   xmlns:hitTest="http://schemas.devexpress.com/winfx/2008/xaml/grid/internal"
+                   xmlns:dxgt="http://schemas.devexpress.com/winfx/2008/xaml/grid/themekeys"
+                   xmlns:dialogs="clr-namespace:DEHPEcosimPro.Views.Dialogs"
+                   Title="Mapping Configuration Dialog" MinWidth="800"
                    MinHeight="600" mc:Ignorable="d">
     <Window.Resources>
         <ResourceDictionary>
@@ -144,7 +148,19 @@
                             <dxg:GridControl.View>
                                 <dxg:TableView HorizontalAlignment="Stretch" VerticalAlignment="Stretch" AllowColumnMoving="True" AllowEditing="False" AllowGrouping="True" AutoWidth="true"
                                                        IsDetailButtonVisibleBinding="{x:Null}"
-                                                       RetainSelectionOnClickOutsideCheckBoxSelector="True" ShowCheckBoxSelectorColumn="true" ShowFilterPanelMode="Never" ShowGroupPanel="False" VerticalScrollbarVisibility="Auto" />
+                                                       RetainSelectionOnClickOutsideCheckBoxSelector="True" ShowCheckBoxSelectorColumn="true" ShowFilterPanelMode="Never" ShowGroupPanel="False" VerticalScrollbarVisibility="Auto" >
+                                    <dxg:TableView.CheckBoxSelectorColumnHeaderTemplate>
+                                        <DataTemplate>
+                                            <dx:MeasurePixelSnapper HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                                    <CheckBox Command="{Binding RelativeSource={RelativeSource FindAncestor, 
+                                                        AncestorType={x:Type dialogs:DstMappingConfigurationDialog}},
+                                                        Path=DataContext.SelectAllValuesCommand}"/>
+                                                </Grid>
+                                            </dx:MeasurePixelSnapper>
+                                        </DataTemplate>
+                                    </dxg:TableView.CheckBoxSelectorColumnHeaderTemplate>
+                                </dxg:TableView>
                             </dxg:GridControl.View>
                             <dxg:GridControl.Columns>
                                 <dxg:GridColumn FieldName="TimeStep" />

--- a/DEHPEcosimPro/Views/DstNetChangePreview.xaml
+++ b/DEHPEcosimPro/Views/DstNetChangePreview.xaml
@@ -71,15 +71,6 @@
                                     <Setter Property="FontWeight" Value="Bold" />
                                     <Setter Property="Foreground" Value="Blue" />
                                 </DataTrigger>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding Row.IsSelectedForTransfer}" Value="False" />
-                                        <Condition Binding="{Binding Row.IsHighlighted}" Value="True" />
-                                    </MultiDataTrigger.Conditions>
-                                    <Setter Property="Background" Value="Yellow"/>
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                    <Setter Property="Foreground" Value="Blue" />
-                                </MultiDataTrigger>
                                 <DataTrigger Binding="{Binding Row.IsSelectedForTransfer}" Value="True">
                                     <Setter Property="Background" Value="LightGreen"/>
                                 </DataTrigger>

--- a/DEHPEcosimPro/Views/MainWindow.xaml
+++ b/DEHPEcosimPro/Views/MainWindow.xaml
@@ -136,7 +136,7 @@
                                     <ColumnDefinition Width="1*" />
                                 </Grid.ColumnDefinitions>
 
-                                <ListView x:Name="Mapping" SelectionMode="Extended" SelectedItem="{Binding MappingViewModel.SelectedRows}" ItemsSource="{Binding MappingViewModel.MappingRows}" Grid.Column="0" HorizontalContentAlignment="Stretch" 
+                                <ListView x:Name="Mapping" SelectionMode="Extended" ItemsSource="{Binding MappingViewModel.MappingRows}" Grid.Column="0" HorizontalContentAlignment="Stretch" 
                                           ItemTemplate="{StaticResource MappedThingRowDataTemplate}" />
                                 <Button ToolTip="Open the history of transfer dialog" Command="{Binding OpenExchangeHistory}" Grid.Column="1" Margin="10" Background="Transparent" BorderBrush="Transparent">
                                     <TextBlock FontSize="18" Text="🕑 Transfer History" TextWrapping="Wrap" TextAlignment="Center"/>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ for:
     - ps: >-
           Write-Host Tag Encountered. Producing Artifact
     - cmd: nuget sources add -name devexpress -source %DEVEXPRESS_API%
-    - cmd: nuget sources add -name github -username RHEAGROUP -password %GITHUB_TOKEN% -source https://nuget.pkg.github.com/RHEAGROUP/index.json
+    - cmd: nuget sources add -name github -username %GITHUB_USER% -password %GITHUB_TOKEN% -source https://nuget.pkg.github.com/RHEAGROUP/index.json
     - cmd: nuget restore -verbosity quiet
   build_script:
     - cmd: msbuild DEHPEcosimPro.sln -p:Configuration=Release /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
@@ -57,7 +57,7 @@ for:
     - cmd: nuget install NUnit.Console -Version 3.11.1 -OutputDirectory testrunner
     - cmd: nuget install NUnit.Runners -Version 3.11.1 -OutputDirectory testrunner
     - cmd: nuget sources add -name devexpress -source %DEVEXPRESS_API%
-    - cmd: nuget sources add -name github -username RHEAGROUP -password %GITHUB_TOKEN% -source https://nuget.pkg.github.com/RHEAGROUP/index.json
+    - cmd: nuget sources add -name github -username %GITHUB_USER% -password %GITHUB_TOKEN% -source https://nuget.pkg.github.com/RHEAGROUP/index.json
     - cmd: nuget restore -verbosity quiet
     - cmd: set "JAVA_HOME=C:\Program Files\Java\jdk11"
     - cmd: set "PATH=C:\Program Files\Java\jdk11\bin;%PATH%"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-ECOSIMPRO/pulls) open
- [x] I have verified that I am following the DEHP-EcosimPro [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-ECOSIMPRO/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
fixes #72

#### Features

- [x] Mapping is fully saved in both direction including value indexes and ready for array mapping
- [x] Mapping is auto loaded
   - [x]  Each time the experiment is paused
   - [x] After transfer

#### Bugs

- [x] Solved performance issue with large set of values
- [x] OPC error from unknown reason X
- [x] context menu is gone
- [x] After transfer manual selection does work anymore only via context menu => MappingDirection.FromDstToHub
- [x] Reset button broken after failing to reset => it also breaks the variable row view models bindings somehow
- [x] Selecting the values is incremental X
- [x] Mapping to Dst isnt reloaded after transfer towards
- [x] Missing loaded value in mapping row when auto loading the mapping from hub to dst 
- [x] Configuration dialog mapping half loaded
- [x] MappedElementRowViewModel Representation not set
<!-- Thanks for contributing to DEHP-EcosimPro! -->