### PR TITLE
SFPT can be mapped to x by 2 OPC array if rowCount matches: Fixes #91

### DIFF
--- a/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
@@ -198,6 +198,12 @@ namespace DEHPEcosimPro.Tests.DstController
             RxApp.MainThreadScheduler = Scheduler.CurrentThread;
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            CDPMessageBus.Current.ClearSubscriptions();
+        }
+
         [Test]
         public void VerifyProperties()
         {

--- a/DEHPEcosimPro.Tests/ViewModel/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
@@ -53,6 +53,7 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
     using DEHPEcosimPro.Services.MappingConfiguration;
     using DEHPEcosimPro.ViewModel.Dialogs;
     using DEHPEcosimPro.ViewModel.Rows;
+    using DEHPEcosimPro.Views.Dialogs;
 
     using Moq;
 
@@ -943,7 +944,84 @@ namespace DEHPEcosimPro.Tests.ViewModel.Dialogs
             this.viewModel.SelectedVariable = array;
             Assert.DoesNotThrow(() => this.viewModel.AreVariableTypesCompatible());
         }
-        
+
+        [Test]
+        public void VerifyTwoDimensionsArraysCompatible()
+        {
+            var listOfVariableRow = new List<VariableRowViewModel>
+            {
+                new VariableRowViewModel((
+                    new ReferenceDescription
+                    {
+                        DisplayName = new LocalizedText(string.Empty, "Mos.a[1,1]"),
+                        NodeId = new NodeId(Guid.NewGuid())
+                    },
+                    new DataValue { Value = 6, ServerTimestamp = DateTime.MinValue })),
+                new VariableRowViewModel((
+                    new ReferenceDescription
+                    {
+                        DisplayName = new LocalizedText(string.Empty, "Mos.a[1,2]"),
+                        NodeId = new NodeId(Guid.NewGuid())
+                    },
+                    new DataValue { Value = 5, ServerTimestamp = DateTime.MinValue }))
+            };
+
+            var array = new ArrayVariableRowViewModel("", listOfVariableRow);
+
+            var parameter = new Parameter
+            {
+                Iid = Guid.NewGuid(),
+                ParameterType = new SampledFunctionParameterType(Guid.NewGuid(), null, null)
+                {
+                    Name = "Kettle[1]",
+                    IndependentParameterType =
+                    {
+                        new IndependentParameterTypeAssignment(Guid.NewGuid(), null, null)
+                        {
+                            ParameterType = new DateTimeParameterType(Guid.NewGuid(), null, null)
+                            {
+                                Name = "Timestamp"
+                            }
+                        }
+                    },
+                    DependentParameterType =
+                    {
+                        new DependentParameterTypeAssignment(Guid.NewGuid(), null, null)
+                        {
+                            ParameterType = new SimpleQuantityKind(Guid.NewGuid(), null, null)
+                            {
+                                Name = "Value"
+                            }
+                        }
+                    }
+                }
+            };
+
+            this.parameter1.Scale = this.measurementScale;
+
+            parameter.ValueSet.Add(new ParameterValueSet
+            {
+                Computed = new ValueArray<string>(new[] { "20", "21" }),
+                ValueSwitch = ParameterSwitchKind.COMPUTED,
+                ActualOption = this.viewModel.SelectedOption,
+                ActualState = this.viewModel.SelectedState
+            });
+
+            var mappedElementDefinitionRowViewModel = new MappedElementDefinitionRowViewModel();
+            this.viewModel.SelectedMappedElement = mappedElementDefinitionRowViewModel;
+            this.viewModel.SelectedMappedElement.SelectedParameter = parameter;
+            this.viewModel.SelectedVariable = array;
+            Assert.DoesNotThrow(() => this.viewModel.AreVariableTypesCompatible());
+
+            this.navigation.Setup(x => x.ShowDxDialog<TwoDimensionsArrayMappingConfigurationDialog,
+                TwoDimensionsArrayMappingConfigurationDialogViewModel>(It.IsAny<TwoDimensionsArrayMappingConfigurationDialogViewModel>())).Returns(true);
+
+            this.viewModel.SelectedMappedElement = mappedElementDefinitionRowViewModel;
+            this.viewModel.SelectedMappedElement.SelectedParameter = parameter;
+            this.viewModel.SelectedVariable = array;
+            Assert.DoesNotThrow(() => this.viewModel.AreVariableTypesCompatible());
+        }
+
         [Test]
         public void TestAreArraysCompatible_1x1()
         {

--- a/DEHPEcosimPro/ViewModel/Dialogs/ArrayParameterMappingConfigurationDialogViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Dialogs/ArrayParameterMappingConfigurationDialogViewModel.cs
@@ -24,8 +24,6 @@
 
 namespace DEHPEcosimPro.ViewModel.Dialogs
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
 
     using CDP4Common.EngineeringModelData;
@@ -44,16 +42,16 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
     public class ArrayParameterMappingConfigurationDialogViewModel : ReactiveObject, ICloseWindowViewModel
     {
         /// <summary>
-        /// Initializes a new <see cref="ArrayParameterMappingConfigurationDialogViewModel"/>
+        /// Initializes a new <see cref="ArrayParameterMappingConfigurationDialogViewModel" />
         /// </summary>
         public ArrayParameterMappingConfigurationDialogViewModel()
         {
         }
 
         /// <summary>
-        /// Initializes a new <see cref="ArrayParameterMappingConfigurationDialogViewModel"/>
-        /// <param name="variable">The <see cref="ArrayVariableRowViewModel"/></param>
-        /// <param name="parameter">The <see cref="ParameterBase"/></param>
+        /// Initializes a new <see cref="ArrayParameterMappingConfigurationDialogViewModel" />
+        /// <param name="variable">The <see cref="ArrayVariableRowViewModel" /></param>
+        /// <param name="parameter">The <see cref="ParameterBase" /></param>
         /// </summary>
         public ArrayParameterMappingConfigurationDialogViewModel(ArrayVariableRowViewModel variable, ParameterOrOverrideBase parameter)
         {
@@ -65,7 +63,7 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
                 this.ParameterNames.AddRange(parameterType.DependentParameterType
                     .Select(x => x.ParameterType.ShortName));
             }
-            
+
             this.hasOnlyOneDimension = variable.HasOnlyOneDimension;
 
             if (variable.HasOnlyOneDimension)
@@ -79,12 +77,12 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
                     this.MappingRows.Add(new ArrayParameterMappingConfigurationRowViewModel(group.Key, group));
                 }
             }
-        
+
             this.ParameterName = parameter.ModelCode();
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="ArrayVariableRowViewModel"/> that is to be mapped
+        /// Gets or sets the <see cref="ArrayVariableRowViewModel" /> that is to be mapped
         /// </summary>
         public ArrayVariableRowViewModel ArrayVariable { get; set; }
 
@@ -99,12 +97,12 @@ namespace DEHPEcosimPro.ViewModel.Dialogs
         public bool hasOnlyOneDimension { get; set; }
 
         /// <summary>
-        /// Gets or sets a collection of <see cref="ArrayParameterMappingConfigurationRowViewModel"/>
+        /// Gets or sets a collection of <see cref="ArrayParameterMappingConfigurationRowViewModel" />
         /// </summary>
         public ReactiveList<ArrayParameterMappingConfigurationRowViewModel> MappingRows { get; } = new();
 
         /// <summary>
-        /// Gets or sets a collection of <see cref="string"/> that will feed the dropdown of the dialog, from parameter
+        /// Gets or sets a collection of <see cref="string" /> that will feed the dropdown of the dialog, from parameter
         /// </summary>
         public ReactiveList<string> ParameterNames { get; set; } = new();
 

--- a/DEHPEcosimPro/ViewModel/Dialogs/TwoDimensionsArrayMappingConfigurationDialogViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Dialogs/TwoDimensionsArrayMappingConfigurationDialogViewModel.cs
@@ -1,0 +1,82 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TwoDimensionsArrayMappingConfigurationDialogViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2022 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.ViewModel.Dialogs
+{
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using DEHPCommon.UserInterfaces.Behaviors;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+
+    using DEHPEcosimPro.ViewModel.Rows;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// ViewModel of the dialog to set the <see cref="IParameterTypeAssignment"/> to map to the correct column/row
+    /// of an <see cref="ArrayVariableRowViewModel"/>
+    /// </summary>
+    public class TwoDimensionsArrayMappingConfigurationDialogViewModel: ReactiveObject, ICloseWindowViewModel
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedItem"/>
+        /// </summary>
+        private IParameterTypeAssignment selectedItem;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TwoDimensionsArrayMappingConfigurationDialogViewModel" /> class.
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase"/></param>
+        public TwoDimensionsArrayMappingConfigurationDialogViewModel(ParameterOrOverrideBase parameter)
+        {
+            var sfpt = parameter.ParameterType as SampledFunctionParameterType;
+            this.ParameterTypeAssignments.AddRange(sfpt.IndependentParameterType);
+            this.ParameterTypeAssignments.AddRange(sfpt.DependentParameterType);
+
+            this.SelectedItem = sfpt.IndependentParameterType.First();
+        }
+
+        /// <summary>
+        /// Gets or sets the selected item in the <see cref="ParameterTypeAssignments"/> collection
+        /// </summary>
+        public IParameterTypeAssignment SelectedItem
+        {
+            get => this.selectedItem;
+            set => this.RaiseAndSetIfChanged(ref this.selectedItem, value);
+        }
+
+        /// <summary>
+        /// A collection of <see cref="IParameterTypeAssignment"/>
+        /// </summary>
+        public ReactiveList<IParameterTypeAssignment> ParameterTypeAssignments { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the behavior instance
+        /// </summary>
+        public ICloseWindowBehavior CloseWindowBehavior { get; set; }
+    }
+}

--- a/DEHPEcosimPro/Views/Dialogs/TwoDimensionsArrayMappingConfigurationDialog.xaml
+++ b/DEHPEcosimPro/Views/Dialogs/TwoDimensionsArrayMappingConfigurationDialog.xaml
@@ -1,0 +1,30 @@
+﻿<dx:DXDialogWindow x:Class="DEHPEcosimPro.Views.Dialogs.TwoDimensionsArrayMappingConfigurationDialog"
+                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                   xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                   xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+                   xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
+                   xmlns:behaviors="clr-namespace:DEHPCommon.UserInterfaces.Behaviors;assembly=DEHPCommon"
+                   mc:Ignorable="d"
+                   Title="Two Dimensions Array Mapping Configuration" Height="120" Width="500"
+                   Topmost="True" WindowStartupLocation="CenterScreen" ResizeMode="NoResize">
+    <dxmvvm:Interaction.Behaviors>
+        <behaviors:CloseWindowBehavior/>
+    </dxmvvm:Interaction.Behaviors>
+    <Grid VerticalAlignment="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Label Grid.Row="0" Content="The first column/row of the Array will contained values from : "></Label>
+        <dxe:ComboBoxEdit Margin="2 0 0 0" Height="25" Grid.Row="0" ItemsSource="{Binding ParameterTypeAssignments}"
+                          SelectedItem="{Binding SelectedItem}" AllowNullInput="False"
+                          DisplayMember="ParameterType.Name" Grid.Column="1"/>
+    </Grid>
+    <dx:DXDialogWindow.FooterButtons>
+        <dx:DialogButton ToolTip="Proceed" Content="Proceed" MinWidth="65" DialogResult="OK"/>
+        <dx:DialogButton ToolTip="Cancel" IsDefault="True" Content="Cancel" IsCancel="True" MinWidth="65" DialogResult="Cancel"/>
+    </dx:DXDialogWindow.FooterButtons>
+</dx:DXDialogWindow>

--- a/DEHPEcosimPro/Views/Dialogs/TwoDimensionsArrayMappingConfigurationDialog.xaml.cs
+++ b/DEHPEcosimPro/Views/Dialogs/TwoDimensionsArrayMappingConfigurationDialog.xaml.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TwoDimensionsArrayMappingConfigurationDialog.xaml.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2022 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHPEcosimPro.Views.Dialogs
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Interaction logic for TwoDimensionsArrayMappingConfigurationDialog.xaml
+    /// </summary>
+    public partial class TwoDimensionsArrayMappingConfigurationDialog
+    {
+        /// <summary>
+        /// Initializes a new <see cref="TwoDimensionsArrayMappingConfigurationDialog"/>
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        public TwoDimensionsArrayMappingConfigurationDialog()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-ECOSIMPRO/pulls) open
- [x] I have verified that I am following the DEHP-EcosimPro [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-ECOSIMPRO/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #91 

A SampledFunctionParameterType can be mapped to a 2 dimensions OPC array with 2 columns if the number of rows matches
<!-- Thanks for contributing to DEHP-EcosimPro! -->