### PR TITLE
Only one timestep 0 after a transfer from hub to dst ; fix #108 #118

### DIFF
--- a/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHPEcosimPro.Tests/DstController/DstControllerTestFixture.cs
@@ -285,8 +285,7 @@ namespace DEHPEcosimPro.Tests.DstController
                                     new DataValue() { Value = 5, ServerTimestamp = DateTime.MinValue }))
                             }
                         },
-                        new List<ElementBase>() {}));
-
+                        new List<ElementBase>()));
 
             Assert.DoesNotThrow(() => this.controller.Map(new List<VariableRowViewModel>()));
 
@@ -363,6 +362,15 @@ namespace DEHPEcosimPro.Tests.DstController
 
             _ = new ElementDefinition() { Parameter = { parameter0, parameter1 } };
 
+            var iid = Guid.NewGuid();
+
+            this.controller.VariableRowViewModels.Add(new VariableRowViewModel((new ReferenceDescription()
+                {
+                    DisplayName = new LocalizedText(string.Empty, "Mos.a"),
+                    NodeId = new NodeId(iid)
+                },
+                new DataValue() { Value = 5, ServerTimestamp = DateTime.MinValue })));
+
             this.controller.SelectedHubMapResultToTransfer.AddRange(
                 new List<MappedElementDefinitionRowViewModel>()
                 {
@@ -374,7 +382,7 @@ namespace DEHPEcosimPro.Tests.DstController
                             new ReferenceDescription()
                             {
                                 DisplayName = new LocalizedText(string.Empty, "Mos.a"),
-                                NodeId = new NodeId(Guid.NewGuid())
+                                NodeId = new NodeId(iid)
                             },
                             new DataValue() {Value = 5, ServerTimestamp = DateTime.MinValue}))
                     },

--- a/DEHPEcosimPro.Tests/ViewModel/Rows/VariableRowViewModelTestFixture.cs
+++ b/DEHPEcosimPro.Tests/ViewModel/Rows/VariableRowViewModelTestFixture.cs
@@ -84,7 +84,14 @@ namespace DEHPEcosimPro.Tests.ViewModel.Rows
             {
                 TimeStamp = DateTime.MinValue.AddDays(1), Id = viewModel.Reference.NodeId.Identifier, Value = 20.9
             });
-            
+
+            CDPMessageBus.Current.SendMessage(new OpcVariableChangedEvent()
+            {
+                TimeStamp = DateTime.MinValue.AddDays(1),
+                Id = viewModel.Reference.NodeId.Identifier,
+                Value = 63.1, Time = 0.01
+            });
+
             Assert.AreEqual(2, viewModel.Values.Count);
             Assert.AreEqual(42, viewModel.AverageValue);
 

--- a/DEHPEcosimPro/DstController/DstController.cs
+++ b/DEHPEcosimPro/DstController/DstController.cs
@@ -641,6 +641,9 @@ namespace DEHPEcosimPro.DstController
             {
                 CDPMessageBus.Current.SendMessage(new OpcVariableChangedEvent(mappedElement));
 
+                this.VariableRowViewModels.FirstOrDefault(x => x.Reference.NodeId.Identifier
+                    .Equals(mappedElement.SelectedVariable.Reference.NodeId.Identifier))?.UpdateValueCollection();
+
                 this.UpdateTransferedHubMapResult(mappedElement);
 
                 this.SelectedHubMapResultToTransfer.Remove(mappedElement);

--- a/DEHPEcosimPro/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -295,10 +295,10 @@ namespace DEHPEcosimPro.ViewModel.NetChangePreview
             this.ContextMenu.Clear();
 
             this.ContextMenu.Add(
-                new ContextMenuItemViewModel("Select all for transfer", "", this.SelectAllCommand, MenuItemKind.Copy, ClassKind.NotThing));
+                new ContextMenuItemViewModel("Select all mapped elements for transfer", "", this.SelectAllCommand, MenuItemKind.Copy, ClassKind.NotThing));
 
             this.ContextMenu.Add(
-                new ContextMenuItemViewModel("Deselect all for transfer", "", this.DeselectAllCommand, MenuItemKind.Delete, ClassKind.NotThing));
+                new ContextMenuItemViewModel("Deselect all mapped elements for transfer", "", this.DeselectAllCommand, MenuItemKind.Delete, ClassKind.NotThing));
         }
 
         /// <summary>

--- a/DEHPEcosimPro/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -521,10 +521,10 @@ namespace DEHPEcosimPro.ViewModel.NetChangePreview
             this.ContextMenu.Clear();
 
             this.ContextMenu.Add(
-                new ContextMenuItemViewModel("Select all for transfer", "", this.SelectAllCommand, MenuItemKind.Copy, ClassKind.NotThing));
+                new ContextMenuItemViewModel("Select all mapped elements for transfer", "", this.SelectAllCommand, MenuItemKind.Copy, ClassKind.NotThing));
 
             this.ContextMenu.Add(
-                new ContextMenuItemViewModel("Deselect all for transfer", "", this.DeselectAllCommand, MenuItemKind.Delete, ClassKind.NotThing));
+                new ContextMenuItemViewModel("Deselect all mapped elements for transfer", "", this.DeselectAllCommand, MenuItemKind.Delete, ClassKind.NotThing));
         }
 
         /// <summary>

--- a/DEHPEcosimPro/ViewModel/Rows/VariableBaseRowViewModel.cs
+++ b/DEHPEcosimPro/ViewModel/Rows/VariableBaseRowViewModel.cs
@@ -345,7 +345,27 @@ namespace DEHPEcosimPro.ViewModel.Rows
         /// <param name="timeStep">The <see cref="DateTime"/> timeStep stamp associated with the <paramref name="value"/></param>
         private void UpdateValueCollection(object value, double timeStep)
         {
-            this.Values.Add(new TimeTaggedValueRowViewModel(value, timeStep));
+            var alreadyExisiting = this.Values.FirstOrDefault(x => x.TimeStep == timeStep);
+
+            if (alreadyExisiting != null)
+            {
+                alreadyExisiting.Value = value;
+            }
+            else
+            {
+                this.Values.Add(new TimeTaggedValueRowViewModel(value, timeStep));
+            }
+        }
+
+        /// <summary>
+        /// Updates the <see cref="Values"/> collection with current value for the latest add timestep
+        /// </summary>
+        public void UpdateValueCollection()
+        {
+            if (this.Values.Any())
+            {
+                this.Values.Last().Value = this.ActualValue;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEHP-ECOSIMPRO/pulls) open
- [x] I have verified that I am following the DEHP-EcosimPro [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEHP-ECOSIMPRO/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #108  #118 

- After a transfer, only one timestep at "0" is present and the correct value is store inside this timestep
- Select all/Deselect all has been replaced to be more explicit
<!-- Thanks for contributing to DEHP-EcosimPro! -->